### PR TITLE
feat: 기본 페이지 + 회원가입 (#7) 

### DIFF
--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -1,0 +1,3 @@
+export default function LoginPage() {
+    return <div>로그인 페이지</div>;
+  }

--- a/frontend/src/app/mypage/page.tsx
+++ b/frontend/src/app/mypage/page.tsx
@@ -1,0 +1,3 @@
+export default function MyPage() {
+    return <div>마이페이지</div>;
+  }

--- a/frontend/src/app/order/page.tsx
+++ b/frontend/src/app/order/page.tsx
@@ -1,0 +1,3 @@
+export default function OrderPage() {
+    return <div>주문 페이지</div>;
+  }

--- a/frontend/src/app/signup/page.tsx
+++ b/frontend/src/app/signup/page.tsx
@@ -1,3 +1,76 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { apiFetch } from "@/lib/apiFetch";
+
 export default function SignupPage() {
-    return <div>회원가입 페이지</div>;
+    const router = useRouter();
+
+    const [form, setForm] = useState({
+        email: "",
+        password: "",
+        nickname: "",
+        address: ""
+        // role은 backend에서 처리
+    });
+
+    const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+      setForm({ ...form, [e.target.name]: e.target.value });
+    };
+
+    const handleSubmit = async (e: React.FormEvent) => {
+      e.preventDefault();
+  
+      try {
+        await apiFetch("/api/signup", {
+          method: "POST",
+          body: JSON.stringify(form),
+        });
+  
+        alert("회원가입 성공");
+        router.push("/login");
+      } catch (err: any) {
+        alert(`회원가입 실패 : ${err.message}`);
+      }
+    };
+  
+    return (
+      <div>
+        <h1>회원가입</h1>
+        <form onSubmit={handleSubmit}>
+          <input
+            name="email"
+            type="email"
+            placeholder="이메일"
+            value={form.email}
+            onChange={handleChange}
+            required
+          /><br />
+          <input
+            name="password"
+            type="password"
+            placeholder="비밀번호"
+            value={form.password}
+            onChange={handleChange}
+            required
+          /><br />
+          <input
+            name="nickname"
+            placeholder="닉네임"
+            value={form.nickname}
+            onChange={handleChange}
+            required
+          /><br />
+          <input
+            name="address"
+            placeholder="주소"
+            value={form.address}
+            onChange={handleChange}
+            required
+          /><br />
+          <button type="submit" className="mt-4 px-4 py-2 bg-gray-500 text-white">회원가입</button>
+        </form>
+      </div>
+    );
   }

--- a/frontend/src/app/signup/page.tsx
+++ b/frontend/src/app/signup/page.tsx
@@ -1,0 +1,3 @@
+export default function SignupPage() {
+    return <div>회원가입 페이지</div>;
+  }

--- a/frontend/src/lib/apiFetch.ts
+++ b/frontend/src/lib/apiFetch.ts
@@ -1,0 +1,25 @@
+export async function apiFetch<T>(
+    path: string,
+    options: RequestInit = {}
+  ): Promise<T> {
+    const baseUrl = "http://localhost:8080"; // 나중에 환경 변수로 변경
+  
+    const token = localStorage.getItem("accessToken");
+  
+    const res = await fetch(`${baseUrl}${path}`, {
+      ...options,
+      headers: {
+        "Content-Type": "application/json",
+        ...(token && { Authorization: `Bearer ${token}` }),
+        ...(options.headers || {}),
+      },
+    });
+  
+    if (!res.ok) {
+      const error = await res.json().catch(() => ({}));
+      throw new Error(error.message || "API 요청 실패");
+    }
+  
+    return res.json();
+  }
+  


### PR DESCRIPTION
Closes #7 <회원가입 페이지 구현>

### 📌 과제 설명
회원가입 기능을 구현했습니다.
사용자는 이메일/비밀번호/닉네임/주소를 입력하여 회원가입할 수 있으며, 성공 시 로그인 페이지로 이동합니다.

### 👩‍💻 요구 사항과 구현 내용
`feat: 라우팅 및 기본 페이지 생성` 
- 기본 페이지 생성.

`feat: 회원가입 입력 폼 구현` 
- 이메일/비밀번호/닉네임/주소 입력 필드 구현
- useState를 활용한 폼 상태 관리
- 공통 API 호출 유틸 함수 apiFetch.ts 작성
- 회원가입 성공 시 로그인 페이지로 이동 처리

### ✅ PR 포인트 & 궁금한 점
현재는 간단한 HTML 폼인데, 이후 Tailwind나 컴포넌트 라이브러리를 적용하도록 하겠습니다.