### PR TITLE
feat: 마이페이지 주문 내역 구현 

### DIFF
--- a/frontend/src/app/mypage/page.tsx
+++ b/frontend/src/app/mypage/page.tsx
@@ -1,3 +1,102 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { apiFetch } from "@/lib/apiFetch"; 
+
+type OrderItem = {
+  menuId: number;
+  name: string;
+  quantity: number;
+  price: number;
+};
+
+type Order = {
+  orderId: number;
+  createdAt: string;
+  totalPrice: number;
+  orderItems: OrderItem[];
+};
+
 export default function MyPage() {
-    return <div>마이페이지</div>;
-  }
+  const [orders, setOrders] = useState<Order[]>([]);
+
+  useEffect(() => {
+    // API 호출
+    apiFetch<Order[]>("/api/myorder")
+      .then((data) => {
+        const sorted = data.sort( // 최신 순 정렬
+          (a, b) =>
+            new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+        );
+        setOrders(sorted);
+      })
+      .catch((err) => {
+        alert("주문 내역 불러오기 실패: " + err.message);
+      });
+
+    /*
+    // 🔧 테스트용 데이터 
+    const mockData: Order[] = [
+      {
+        orderId: 101,
+        createdAt: "2025-07-14T13:23:12",
+        totalPrice: 14500,
+        orderItems: [
+          { menuId: 1, name: "아메리카노", quantity: 2, price: 5000 },
+          { menuId: 3, name: "카페라떼", quantity: 1, price: 4500 },
+        ],
+      },
+      {
+        orderId: 102,
+        createdAt: "2025-07-15T09:12:00",
+        totalPrice: 6000,
+        orderItems: [
+          { menuId: 2, name: "카푸치노", quantity: 1, price: 6000 },
+        ],
+      },
+    ];
+
+    const sorted = mockData.sort(
+      (a, b) =>
+        new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+    );
+    setOrders(sorted);
+    */
+  }, []);
+
+  return (
+    <div className="p-6">
+      <h1 className="text-xl font-bold mb-4">내 주문 내역</h1>
+
+      {orders.length === 0 ? (
+        <p>주문 내역이 없습니다.</p>
+      ) : (
+        <ul className="space-y-6">
+          {orders.map((order) => (
+            <li
+              key={order.orderId}
+              className="border p-4 rounded-xl shadow bg-white"
+            >
+              <p className="text-sm text-gray-500 mb-2">
+                주문 일시: {new Date(order.createdAt).toLocaleString()}
+              </p>
+              <ul className="divide-y">
+                {order.orderItems.map((item, index) => (
+                  <li key={index} className="flex justify-between py-1">
+                    <span>
+                      {item.name} x {item.quantity}
+                    </span>
+                    <span>{item.price * item.quantity}원</span>
+                  </li>
+                ))}
+              </ul>
+              <p className="text-right mt-2 font-semibold">
+                총 결제 금액: {order.totalPrice.toLocaleString()}원
+              </p>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #10 <마이페이지 주문 내역>

### 📌 과제 설명
주문 등록 페이지에서 넘어간 마이페이지, 즉 주문 내역 화면을 구현했습니다.
주문 데이터를 최신순으로 정렬하여 사용자에게 최근 주문이 먼저 보이도록 했습니다.

### 👩‍💻 요구 사항과 구현 내용
GET /api/myorder 호출을 통해 사용자 주문 내역 조회
주문 내역이 없을 경우 안내 메시지 출력
각 주문 항목에 대해 -> 주문 일시 표시 (createdAt) / 메뉴 이름, 수량, 금액 표시 / 주문별 총 결제 금액 표시
주문 내역을 최신순으로 정렬
(주석 처리) 테스트용 mock 데이터도 함께 남겨둠

### ✅ PR 포인트 & 궁금한 점
현재는 테스트용 데이터로 동작 정상 확인을 완료했습니다.
우선은 사용자가 주문했던 내역들이 모두 나오도록 했는데, 
추후에 결제 후 이동 페이지를 추가할 가능성도 있을 것 같습니다.