### PR TITLE
refactor: 컴포넌트 분리

### DIFF
--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -5,6 +5,7 @@ import { useLogin } from "@/hooks/useLogin";
 import { LoginForm } from "@/types";
 import { InputField } from "@/components/ui/InputField";
 import { Button } from "@/components/ui/Button";
+import { ErrorMessage } from "@/components/ui/ErrorMessage";
 
 export default function LoginPage() {
   const { login, isLoading, errorMessage } = useLogin();
@@ -22,7 +23,7 @@ export default function LoginPage() {
   return (
     <div className="p-6">
       <h1 className="text-xl font-bold mb-4">로그인</h1>
-      {errorMessage && <p className="text-red-500">{errorMessage}</p>}
+      <ErrorMessage message={errorMessage} />
 
       <form onSubmit={handleSubmit}>
         <InputField

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -3,13 +3,12 @@
 import { useState } from "react";
 import { useLogin } from "@/hooks/useLogin";
 import { LoginForm } from "@/types";
+import { InputField } from "@/components/ui/InputField";
+import { Button } from "@/components/ui/Button";
 
 export default function LoginPage() {
   const { login, isLoading, errorMessage } = useLogin();
-  const [form, setForm] = useState<LoginForm>({
-    email: "",
-    password: "",
-  });
+  const [form, setForm] = useState<LoginForm>({ email: "", password: "" });
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setForm({ ...form, [e.target.name]: e.target.value });
@@ -21,36 +20,28 @@ export default function LoginPage() {
   };
 
   return (
-    <div>
-      <h1>로그인</h1>
-
-      {/* 오류 메시지 표시 */}
+    <div className="p-6">
+      <h1 className="text-xl font-bold mb-4">로그인</h1>
       {errorMessage && <p className="text-red-500">{errorMessage}</p>}
 
       <form onSubmit={handleSubmit}>
-        <input
+        <InputField
           name="email"
           type="email"
           placeholder="이메일"
           value={form.email}
           onChange={handleChange}
-          required
-        /><br />
-        <input
+        />
+        <InputField
           name="password"
           type="password"
           placeholder="비밀번호"
           value={form.password}
           onChange={handleChange}
-          required
-        /><br />
-        <button
-          type="submit"
-          className="mt-4 px-4 py-2 bg-gray-500 text-white"
-          disabled={isLoading}
-        >
+        />
+        <Button type="submit" disabled={isLoading}>
           {isLoading ? "로그인 중..." : "로그인"}
-        </button>
+        </Button>
       </form>
     </div>
   );

--- a/frontend/src/app/mypage/page.tsx
+++ b/frontend/src/app/mypage/page.tsx
@@ -2,7 +2,8 @@
 
 import { useEffect, useState } from "react";
 import { apiFetch } from "@/lib/apiFetch"; 
-import { Order, OrderItem } from "@/types";
+import { Order } from "@/types";
+import { OrderCard } from "@/components/mypage/OrderCard";
 
 export default function MyPage() {
   const [orders, setOrders] = useState<Order[]>([]);
@@ -60,27 +61,7 @@ export default function MyPage() {
       ) : (
         <ul className="space-y-6">
           {orders.map((order) => (
-            <li
-              key={order.orderId}
-              className="border p-4 rounded-xl shadow bg-white"
-            >
-              <p className="text-sm text-gray-500 mb-2">
-                주문 일시: {new Date(order.createdAt).toLocaleString()}
-              </p>
-              <ul className="divide-y">
-                {order.orderItems.map((item, index) => (
-                  <li key={index} className="flex justify-between py-1">
-                    <span>
-                      {item.name} x {item.quantity}
-                    </span>
-                    <span>{item.price * item.quantity}원</span>
-                  </li>
-                ))}
-              </ul>
-              <p className="text-right mt-2 font-semibold">
-                총 결제 금액: {order.totalPrice.toLocaleString()}원
-              </p>
-            </li>
+            <OrderCard key={order.orderId} order={order} />
           ))}
         </ul>
       )}

--- a/frontend/src/app/order/page.tsx
+++ b/frontend/src/app/order/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import { apiFetch } from "@/lib/apiFetch";
 import { MenuItem, CartItem } from "@/types";
 import { useOrder } from "@/hooks/useOrder";
+import { CartItemCard } from "@/components/order/CartItemCard";
 
 export default function OrderPage() {
   const [menus, setMenus] = useState<MenuItem[]>([]);
@@ -21,7 +22,9 @@ export default function OrderPage() {
       const existing = prev.find((item) => item.menu.id === menu.id);
       if (existing) {
         return prev.map((item) =>
-          item.menu.id === menu.id ? { ...item, quantity: item.quantity + 1 } : item
+          item.menu.id === menu.id
+            ? { ...item, quantity: item.quantity + 1 }
+            : item
         );
       } else {
         return [...prev, { menu, quantity: 1 }];
@@ -39,7 +42,10 @@ export default function OrderPage() {
 
       <div className="space-y-4">
         {menus.map((menu) => (
-          <div key={menu.id} className="border p-4 rounded shadow-sm flex justify-between items-center">
+          <div
+            key={menu.id}
+            className="border p-4 rounded shadow-sm flex justify-between items-center"
+          >
             <div>
               <p className="font-semibold">{menu.name}</p>
               <p className="text-sm text-gray-500">{menu.description}</p>
@@ -62,56 +68,35 @@ export default function OrderPage() {
       ) : (
         <div className="space-y-2 mt-4">
           {cart.map((item) => (
-            <div key={item.menu.id} className="border p-3 flex justify-between items-center rounded">
-              <div>
-                <p className="font-semibold">{item.menu.name}</p>
-                <p className="text-sm text-gray-500">
-                  ₩{item.menu.price.toLocaleString()}
-                </p>
-              </div>
-              <div className="flex items-center gap-2">
-                <button
-                  type="button"
-                  onClick={() =>
-                    setCart((prev) =>
-                      prev.map((c) =>
-                        c.menu.id === item.menu.id
-                          ? { ...c, quantity: Math.max(0, c.quantity - 1) }
-                          : c
-                      ).filter((c) => c.quantity > 0)
+            <CartItemCard
+              key={item.menu.id}
+              item={item}
+              onIncrease={() =>
+                setCart((prev) =>
+                  prev.map((c) =>
+                    c.menu.id === item.menu.id
+                      ? { ...c, quantity: c.quantity + 1 }
+                      : c
+                  )
+                )
+              }
+              onDecrease={() =>
+                setCart((prev) =>
+                  prev
+                    .map((c) =>
+                      c.menu.id === item.menu.id
+                        ? { ...c, quantity: Math.max(0, c.quantity - 1) }
+                        : c
                     )
-                  }
-                  className="px-2 py-1 bg-gray-300 rounded"
-                >
-                  -
-                </button>
-                <span>{item.quantity}</span>
-                <button
-                  type="button"
-                  onClick={() =>
-                    setCart((prev) =>
-                      prev.map((c) =>
-                        c.menu.id === item.menu.id ? { ...c, quantity: c.quantity + 1 } : c
-                      )
-                    )
-                  }
-                  className="px-2 py-1 bg-gray-300 rounded"
-                >
-                  +
-                </button>
-                <button
-                  type="button"
-                  onClick={() =>
-                    setCart((prev) =>
-                      prev.filter((c) => c.menu.id !== item.menu.id)
-                    )
-                  }
-                  className="px-2 py-1 bg-red-400 text-white rounded"
-                >
-                  삭제
-                </button>
-              </div>
-            </div>
+                    .filter((c) => c.quantity > 0)
+                )
+              }
+              onRemove={() =>
+                setCart((prev) =>
+                  prev.filter((c) => c.menu.id !== item.menu.id)
+                )
+              }
+            />
           ))}
         </div>
       )}
@@ -131,6 +116,10 @@ export default function OrderPage() {
       >
         {isLoading ? "결제 처리 중..." : "결제하기"}
       </button>
+
+      {errorMessage && (
+        <p className="text-red-500 mt-2 text-sm">{errorMessage}</p>
+      )}
     </div>
   );
 }

--- a/frontend/src/app/order/page.tsx
+++ b/frontend/src/app/order/page.tsx
@@ -4,7 +4,9 @@ import { useEffect, useState } from "react";
 import { apiFetch } from "@/lib/apiFetch";
 import { MenuItem, CartItem } from "@/types";
 import { useOrder } from "@/hooks/useOrder";
+import { MenuCard } from "@/components/order/MenuCard";
 import { CartItemCard } from "@/components/order/CartItemCard";
+import { ErrorMessage } from "@/components/ui/ErrorMessage";
 
 export default function OrderPage() {
   const [menus, setMenus] = useState<MenuItem[]>([]);
@@ -41,25 +43,14 @@ export default function OrderPage() {
       <h1 className="text-xl font-bold mb-4">메뉴</h1>
 
       <div className="space-y-4">
-        {menus.map((menu) => (
-          <div
-            key={menu.id}
-            className="border p-4 rounded shadow-sm flex justify-between items-center"
-          >
-            <div>
-              <p className="font-semibold">{menu.name}</p>
-              <p className="text-sm text-gray-500">{menu.description}</p>
-              <p className="text-sm">₩{menu.price.toLocaleString()}</p>
-            </div>
-            <button
-              onClick={() => handleAddToCart(menu)}
-              className="px-3 py-1 bg-blue-600 text-white rounded hover:bg-blue-700 transition"
-            >
-              담기
-            </button>
-          </div>
-        ))}
-      </div>
+      {menus.map((menu) => (
+        <MenuCard
+          key={menu.id}
+          menu={menu}
+          onAdd={() => handleAddToCart(menu)}
+        />
+      ))}
+    </div>
 
       <h2 className="text-lg font-bold mt-8">장바구니</h2>
 
@@ -117,9 +108,7 @@ export default function OrderPage() {
         {isLoading ? "결제 처리 중..." : "결제하기"}
       </button>
 
-      {errorMessage && (
-        <p className="text-red-500 mt-2 text-sm">{errorMessage}</p>
-      )}
+      <ErrorMessage message={errorMessage} />
     </div>
   );
 }

--- a/frontend/src/app/signup/page.tsx
+++ b/frontend/src/app/signup/page.tsx
@@ -6,6 +6,7 @@ import { useSignup } from "@/hooks/useSignup";
 import { SignupForm } from "@/types";
 import { InputField } from "@/components/ui/InputField";
 import { Button } from "@/components/ui/Button";
+import { ErrorMessage } from "@/components/ui/ErrorMessage";
 
 export default function SignupPage() {
   const router = useRouter();
@@ -30,7 +31,7 @@ export default function SignupPage() {
   return (
     <div className="p-6">
       <h1 className="text-xl font-bold mb-4">회원가입</h1>
-      {errorMessage && <p className="text-red-500">{errorMessage}</p>}
+      <ErrorMessage message={errorMessage} />
 
       <form onSubmit={handleSubmit}>
         <InputField name="email" type="email" placeholder="이메일" value={form.email} onChange={handleChange} />

--- a/frontend/src/app/signup/page.tsx
+++ b/frontend/src/app/signup/page.tsx
@@ -4,11 +4,12 @@ import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { useSignup } from "@/hooks/useSignup";
 import { SignupForm } from "@/types";
+import { InputField } from "@/components/ui/InputField";
+import { Button } from "@/components/ui/Button";
 
 export default function SignupPage() {
   const router = useRouter();
   const { signup, isLoading, errorMessage } = useSignup();
-
   const [form, setForm] = useState<SignupForm>({
     email: "",
     password: "",
@@ -22,52 +23,24 @@ export default function SignupPage() {
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    signup(form);
-    if (!isLoading && !errorMessage) {
-      router.push("/login"); 
-    }
+    await signup(form);
+    if (!isLoading && !errorMessage) router.push("/login");
   };
 
   return (
-    <div>
-      <h1>회원가입</h1>
-      {/* 오류 메시지 표시 */}
+    <div className="p-6">
+      <h1 className="text-xl font-bold mb-4">회원가입</h1>
       {errorMessage && <p className="text-red-500">{errorMessage}</p>}
 
       <form onSubmit={handleSubmit}>
-        <input
-          name="email"
-          type="email"
-          placeholder="이메일"
-          value={form.email}
-          onChange={handleChange}
-          required
-        /><br />
-        <input
-          name="password"
-          type="password"
-          placeholder="비밀번호"
-          value={form.password}
-          onChange={handleChange}
-          required
-        /><br />
-        <input
-          name="nickname"
-          placeholder="닉네임"
-          value={form.nickname}
-          onChange={handleChange}
-          required
-        /><br />
-        <input
-          name="address"
-          placeholder="주소"
-          value={form.address}
-          onChange={handleChange}
-          required
-        /><br />
-        <button type="submit" className="mt-4 px-4 py-2 bg-gray-500 text-white" disabled={isLoading}>
+        <InputField name="email" type="email" placeholder="이메일" value={form.email} onChange={handleChange} />
+        <InputField name="password" type="password" placeholder="비밀번호" value={form.password} onChange={handleChange} />
+        <InputField name="nickname" type="text" placeholder="닉네임" value={form.nickname} onChange={handleChange} />
+        <InputField name="address" type="text" placeholder="주소" value={form.address} onChange={handleChange} />
+
+        <Button type="submit" disabled={isLoading}>
           {isLoading ? "회원가입 중..." : "회원가입"}
-        </button>
+        </Button>
       </form>
     </div>
   );

--- a/frontend/src/app/signup/page.tsx
+++ b/frontend/src/app/signup/page.tsx
@@ -2,76 +2,73 @@
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
-import { apiFetch } from "@/lib/apiFetch";
+import { useSignup } from "@/hooks/useSignup";
 import { SignupForm } from "@/types";
 
 export default function SignupPage() {
-    const router = useRouter();
+  const router = useRouter();
+  const { signup, isLoading, errorMessage } = useSignup();
 
-    const [form, setForm] = useState<SignupForm>({
-        email: "",
-        password: "",
-        nickname: "",
-        address: ""
-        // role은 backend에서 처리
-    });
+  const [form, setForm] = useState<SignupForm>({
+    email: "",
+    password: "",
+    nickname: "",
+    address: "",
+  });
 
-    const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-      setForm({ ...form, [e.target.name]: e.target.value });
-    };
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setForm({ ...form, [e.target.name]: e.target.value });
+  };
 
-    const handleSubmit = async (e: React.FormEvent) => {
-      e.preventDefault();
-  
-      try {
-        await apiFetch("/api/signup", {
-          method: "POST",
-          body: JSON.stringify(form),
-        });
-  
-        alert("회원가입 성공");
-        router.push("/login");
-      } catch (err: any) {
-        alert(`회원가입 실패 : ${err.message}`);
-      }
-    };
-  
-    return (
-      <div>
-        <h1>회원가입</h1>
-        <form onSubmit={handleSubmit}>
-          <input
-            name="email"
-            type="email"
-            placeholder="이메일"
-            value={form.email}
-            onChange={handleChange}
-            required
-          /><br />
-          <input
-            name="password"
-            type="password"
-            placeholder="비밀번호"
-            value={form.password}
-            onChange={handleChange}
-            required
-          /><br />
-          <input
-            name="nickname"
-            placeholder="닉네임"
-            value={form.nickname}
-            onChange={handleChange}
-            required
-          /><br />
-          <input
-            name="address"
-            placeholder="주소"
-            value={form.address}
-            onChange={handleChange}
-            required
-          /><br />
-          <button type="submit" className="mt-4 px-4 py-2 bg-gray-500 text-white">회원가입</button>
-        </form>
-      </div>
-    );
-  }
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    signup(form);
+    if (!isLoading && !errorMessage) {
+      router.push("/login"); 
+    }
+  };
+
+  return (
+    <div>
+      <h1>회원가입</h1>
+      {/* 오류 메시지 표시 */}
+      {errorMessage && <p className="text-red-500">{errorMessage}</p>}
+
+      <form onSubmit={handleSubmit}>
+        <input
+          name="email"
+          type="email"
+          placeholder="이메일"
+          value={form.email}
+          onChange={handleChange}
+          required
+        /><br />
+        <input
+          name="password"
+          type="password"
+          placeholder="비밀번호"
+          value={form.password}
+          onChange={handleChange}
+          required
+        /><br />
+        <input
+          name="nickname"
+          placeholder="닉네임"
+          value={form.nickname}
+          onChange={handleChange}
+          required
+        /><br />
+        <input
+          name="address"
+          placeholder="주소"
+          value={form.address}
+          onChange={handleChange}
+          required
+        /><br />
+        <button type="submit" className="mt-4 px-4 py-2 bg-gray-500 text-white" disabled={isLoading}>
+          {isLoading ? "회원가입 중..." : "회원가입"}
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/frontend/src/components/mypage/OrderCard.tsx
+++ b/frontend/src/components/mypage/OrderCard.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import { Order } from "@/types";
+
+export function OrderCard({ order }: { order: Order }) {
+  return (
+    <li className="border p-4 rounded-xl shadow bg-white">
+      <p className="text-sm text-gray-500 mb-2">
+        주문 일시: {new Date(order.createdAt).toLocaleString()}
+      </p>
+      <ul className="divide-y">
+        {order.orderItems.map((item, idx) => (
+          <li key={idx} className="flex justify-between py-1">
+            <span>{item.name} x {item.quantity}</span>
+            <span>{item.price * item.quantity}원</span>
+          </li>
+        ))}
+      </ul>
+      <p className="text-right mt-2 font-semibold">
+        총 결제 금액: {order.totalPrice.toLocaleString()}원
+      </p>
+    </li>
+  );
+}

--- a/frontend/src/components/order/CartItemCard.tsx
+++ b/frontend/src/components/order/CartItemCard.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { CartItem } from "@/types";
+
+export function CartItemCard({
+  item,
+  onIncrease,
+  onDecrease,
+  onRemove,
+}: {
+  item: CartItem;
+  onIncrease: () => void;
+  onDecrease: () => void;
+  onRemove: () => void;
+}) {
+  return (
+    <div className="border p-3 flex justify-between items-center rounded">
+      <div>
+        <p className="font-semibold">{item.menu.name}</p>
+        <p className="text-sm text-gray-500">
+          ₩{item.menu.price.toLocaleString()}
+        </p>
+      </div>
+      <div className="flex items-center gap-2">
+        <button onClick={onDecrease} className="px-2 py-1 bg-gray-300 rounded">-</button>
+        <span>{item.quantity}</span>
+        <button onClick={onIncrease} className="px-2 py-1 bg-gray-300 rounded">+</button>
+        <button onClick={onRemove} className="px-2 py-1 bg-red-400 text-white rounded">삭제</button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/order/MenuCard.tsx
+++ b/frontend/src/components/order/MenuCard.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { MenuItem } from "@/types";
+
+export function MenuCard({
+  menu,
+  onAdd,
+}: {
+  menu: MenuItem;
+  onAdd: () => void;
+}) {
+  return (
+    <div className="border p-4 rounded shadow-sm flex justify-between items-center">
+      <div>
+        <p className="font-semibold">{menu.name}</p>
+        <p className="text-sm text-gray-500">{menu.description}</p>
+        <p className="text-sm">₩{menu.price.toLocaleString()}</p>
+      </div>
+      <button
+        onClick={onAdd}
+        className="px-3 py-1 bg-blue-600 text-white rounded hover:bg-blue-700 transition"
+      >
+        담기
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/components/ui/Button.tsx
+++ b/frontend/src/components/ui/Button.tsx
@@ -1,0 +1,22 @@
+export const Button = ({
+    type,
+    disabled,
+    children,
+    onClick,
+  }: {
+    type: "button" | "submit";
+    disabled: boolean;
+    children: React.ReactNode;
+    onClick?: () => void;
+  }) => {
+    return (
+      <button
+        type={type}
+        onClick={onClick}
+        className="mt-4 px-4 py-2 bg-gray-500 text-white"
+        disabled={disabled}
+      >
+        {children}
+      </button>
+    );
+  };

--- a/frontend/src/components/ui/ErrorMessage.tsx
+++ b/frontend/src/components/ui/ErrorMessage.tsx
@@ -1,0 +1,6 @@
+"use client";
+
+export function ErrorMessage({ message }: { message?: string }) {
+  if (!message) return null;
+  return <p className="text-red-500 text-sm mt-2">{message}</p>;
+}

--- a/frontend/src/components/ui/InputField.tsx
+++ b/frontend/src/components/ui/InputField.tsx
@@ -1,0 +1,24 @@
+export const InputField = ({
+    name,
+    type,
+    placeholder,
+    value,
+    onChange,
+  }: {
+    name: string;
+    type: string;
+    placeholder: string;
+    value: string;
+    onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  }) => {
+    return (
+      <input
+        name={name}
+        type={type}
+        placeholder={placeholder}
+        value={value}
+        onChange={onChange}
+        required
+      />
+    );
+  };

--- a/frontend/src/hooks/useSignup.ts
+++ b/frontend/src/hooks/useSignup.ts
@@ -1,0 +1,28 @@
+import { useState } from "react";
+import { apiFetch } from "@/lib/apiFetch";
+import { SignupForm } from "@/types";
+
+export function useSignup() {
+  const [isLoading, setIsLoading] = useState(false);
+  const [errorMessage, setErrorMessage] = useState("");
+
+  const signup = async (form: SignupForm) => {
+    setErrorMessage(""); // 에러 메시지 초기화
+    setIsLoading(true); // 로딩 시작
+
+    try {
+      await apiFetch("/api/signup", {
+        method: "POST",
+        body: JSON.stringify(form),
+      });
+
+      alert("회원가입 성공");
+    } catch (err: any) {
+      setErrorMessage(`회원가입 실패: ${err.message}`);
+    } finally {
+      setIsLoading(false); // 로딩 끝
+    }
+  };
+
+  return { signup, isLoading, errorMessage };
+}


### PR DESCRIPTION
Closes #44 <컴포넌트 분리>
### 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
이전 커스텀 훅 분리 작업 때 놓쳤던 회원가입 훅도 다시 분리했습니다.
이번엔 공통 UI 컴포넌트들을 분리하여 가독성과 유지보수성을 향상했습니다.

### 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
`회원가입/로그인 폼`
: InputField, Button 컴포넌트를 생성하여 로그인/회원가입 폼에서 중복된 UI 요소를 분리/재사용하도록 개선.

`주문 등록 페이지 개선`
: 메뉴 리스트 렌더링 부분을 MenuCard 컴포넌트로 분리.

`에러 메시지 공통 컴포넌트화`
: ErrorMessage 컴포넌트를 생성하고 회원가입/로그인/주문 등록 페이지에 적용.

### ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
현재는 최소한의 기능만 하도록 디자인되어 있는데, 
이후에 디자인 수정하면서 컴포넌트들도 다시 수정될 수 있을 것 같습니다.