### PR TITLE
feat: 관리자 주문 목록 조회 페이지 추가 + Order 타입 확장

### DIFF
--- a/frontend/src/app/admin/orders/page.tsx
+++ b/frontend/src/app/admin/orders/page.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Order, OrderItem } from "@/types"; // 공용 타입 사용
+
+export default function Orders() {
+  const [orders, setOrders] = useState<Order[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const fetchOrders = async () => {
+    try {
+      const res = await fetch("http://localhost:8080/admin/orders");
+      if (!res.ok) throw new Error("주문 목록 불러오기 실패");
+
+      const data: Order[] = await res.json();
+      setOrders(data);
+    } catch (error) {
+      console.error("주문 목록을 불러오는 중 오류:", error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchOrders();
+  }, []);
+
+  if (loading) return <p>로딩 중입니다...</p>;
+
+  const summarizeOrderItems = (orderItems: OrderItem[]) =>
+    orderItems.map((item) => `${item.name}×${item.quantity}`).join(", ");
+
+  return (
+    <div>
+      <h1 className="text-2xl font-bold mb-4">전체 주문 목록 조회</h1>
+
+      <table className="w-full border-collapse bg-white shadow">
+        <thead>
+          <tr className="bg-gray-100">
+            <th className="border p-2">주문번호</th>
+            <th className="border p-2">주문일시</th>
+            <th className="border p-2">주문자 이메일</th>
+            <th className="border p-2">주문상품</th>
+            <th className="border p-2">총액</th>
+          </tr>
+        </thead>
+        <tbody>
+          {orders.map((order) => (
+            <tr key={order.orderId}>
+              <td className="border p-2 text-center">{order.orderId}</td>
+              <td className="border p-2 text-center">
+                {new Date(order.createdAt).toLocaleString()}
+              </td>
+              <td className="border p-2">{order.email}</td>
+              <td className="border p-2">{summarizeOrderItems(order.orderItems)}</td>
+              <td className="border p-2 text-right">
+                {order.totalPrice.toLocaleString()}원
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/frontend/src/types/order.ts
+++ b/frontend/src/types/order.ts
@@ -7,6 +7,8 @@ export type OrderItem = {
 
 export type Order = {
   orderId: number;
+  userId: number;
+  email: string;
   createdAt: string;
   totalPrice: number;
   orderItems: OrderItem[];


### PR DESCRIPTION
Close #15 <주문 내역 조회 페이지 구현>


📌 과제 설명
1. 관리자 주문 목록 조회 페이지 구현
- /admin/orders API를 호출하여 주문 데이터를 가져오고, 표 형태로 화면에 출력

2. Order 타입 확장
- src/app/type/order.js에서 Order 타입에 userId, email 필드를 추가

👩‍💻 요구 사항과 구현 내용
1. 전체 주문 목록 조회 페이지 (feat: 전체 주문 목록 조회 페이지 추가)
- /admin/orders API 연동
- 주문 목록을 표 형태로 출력
- 헬퍼 함수 summarizeOrderItems 추가 → OrderItem[] → "상품명×수량, …" 문자열로 변환
- Order, OrderItem 공용 타입 사용

2. 주문 타입 확장 (feat: 주문 타입에 사용자 정보 필드 추가)
- Order 타입에 userId, email 필드를 추가

✅ PR 포인트 & 궁금한 점
- API 응답 데이터와 일치하도록 Order 타입에 userId, email 필드를 추가 했습니다.
- 주문 상품을 현재 "상품명×수량"으로 표현했는데, 더 직관적인 포맷이 필요할까요?