### PR TITLE
feat: API 경로 수정 + 테스트용 memberId 자동 추가 로직 추가 

### DIFF
--- a/frontend/src/_hooks/useLogin.ts
+++ b/frontend/src/_hooks/useLogin.ts
@@ -27,7 +27,7 @@ export function useLogin() {
     }
 
     try {
-      const res = await apiFetch<{ token: string }>("/api/login", {
+      const res = await apiFetch<{ token: string }>("/login", {
         method: "POST",
         body: JSON.stringify(form),
       });

--- a/frontend/src/_hooks/useOrder.ts
+++ b/frontend/src/_hooks/useOrder.ts
@@ -27,9 +27,9 @@ export function useOrder() {
     setState({ ...state, errorMessage: "", isLoading: true });
 
     try {
-      await apiFetch("/api/orders", {
+      await apiFetch("/orders", {
         method: "POST",
-        body: JSON.stringify({ items }),
+        body: JSON.stringify({ orderMenus: items }),
       });
 
       toast.success("주문이 완료되었습니다.");

--- a/frontend/src/_hooks/useSignup.ts
+++ b/frontend/src/_hooks/useSignup.ts
@@ -12,7 +12,7 @@ export function useSignup() {
     setIsLoading(true); // 로딩 시작
 
     try {
-      await apiFetch("/api/signup", {
+      await apiFetch("/signup", {
         method: "POST",
         body: JSON.stringify(form),
       });

--- a/frontend/src/app/mypage/page.tsx
+++ b/frontend/src/app/mypage/page.tsx
@@ -10,7 +10,7 @@ export default function MyPage() {
 
   useEffect(() => {
     // API 호출
-    apiFetch<Order[]>("/api/myorder")
+    apiFetch<Order[]>("/myorder")
       .then((data) => {
         const sorted = data.sort( // 최신 순 정렬
           (a, b) =>

--- a/frontend/src/app/order/page.tsx
+++ b/frontend/src/app/order/page.tsx
@@ -13,30 +13,8 @@ export default function OrderPage() {
   const [cart, setCart] = useState<CartItem[]>([]);
   const { order, isLoading, errorMessage } = useOrder();
 
-  /*
-  // 테스트용 메뉴 목록
   useEffect(() => {
-    const mockMenus: MenuItem[] = [
-      {
-        id: 1,
-        name: "아메리카노",
-        description: "시원한 아이스 아메리카노",
-        price: 3000,
-      },
-      {
-        id: 2,
-        name: "카페라떼",
-        description: "부드러운 우유 거품의 라떼",
-        price: 4000,
-      },
-    ];
-
-    setMenus(mockMenus);
-  }, []);
-  */  
-
-  useEffect(() => {
-    apiFetch<MenuItem[]>("/api/menus")
+    apiFetch<MenuItem[]>("/menus") 
       .then(setMenus)
       .catch((err) => alert("메뉴 불러오기 실패: " + err.message));
   }, []);

--- a/frontend/src/lib/apiFetch.ts
+++ b/frontend/src/lib/apiFetch.ts
@@ -1,25 +1,38 @@
 export async function apiFetch<T>(
-    path: string,
-    options: RequestInit = {}
-  ): Promise<T> {
-    const baseUrl = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8080";
-  
-    const token = localStorage.getItem("accessToken");
-  
-    const res = await fetch(`${baseUrl}${path}`, {
-      ...options,
-      headers: {
-        "Content-Type": "application/json",
-        ...(token && { Authorization: `Bearer ${token}` }),
-        ...(options.headers || {}),
-      },
-    });
-  
-    if (!res.ok) {
-      const error = await res.json().catch(() => ({}));
-      throw new Error(error.message || "API 요청 실패");
-    }
-  
-    return res.json();
+  path: string,
+  options: RequestInit = {}
+): Promise<T> {
+  const baseUrl = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8080";
+  const token = localStorage.getItem("accessToken");
+
+  // 테스트용
+  // memberId 안 붙는 API 목록
+  const skipMemberIdPaths = ["/signup", "/login"];
+
+  // 현재 요청이 memberId를 붙여야 하는 API인가?
+  const needsMemberId = !skipMemberIdPaths.some((skip) => path.startsWith(skip));
+
+  const url = needsMemberId
+    ? path.includes("?")
+      ? `${path}&memberId=1`
+      : `${path}?memberId=1`
+    : path;
+
+  // 백엔드 토큰 작업 완료 -> const url = path; 로 수정.
+
+  const res = await fetch(`${baseUrl}${url}`, {
+    ...options,
+    headers: {
+      "Content-Type": "application/json",
+      ...(token && { Authorization: `Bearer ${token}` }),
+      ...(options.headers || {}),
+    },
+  });
+
+  if (!res.ok) {
+    const error = await res.json().catch(() => ({}));
+    throw new Error(error.message || "API 요청 실패");
   }
-  
+
+  return res.json();
+}


### PR DESCRIPTION
### 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
기존에 잘못 작성되어 있던 API  경로를 수정하고, 현재 백엔드의 토큰 작업이 완료되지 않아 테스트용 memberId 로직 추가를 통해 백엔드와 연동된 것을 확인할 수 있습니다.

### 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
1) API 경로 정리
- 기존에 잘못 작성되어 있던 `/api/...` 형태의 API 경로들을 실제 백엔드에 맞게 수정
-  `/signup`, `/login`, `/menus`, `/orders`, `/myorder` 


2) 테스트용 `memberId` 자동 추가 로직
- 현재 백엔드가 `@AuthenticationPrincipal`이 아닌 `@RequestParam` 기반으로 `memberId`를 요구하고 있어, 
   개발 편의를 위해 `apiFetch` 내에서 자동으로 `memberId=1`을 붙이는 임시 로직 추가
- 단, 아래 경로(`/signup`, `/login`)에는 memberId가 붙지 않도록 예외 처리

### ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
백엔드가 추후 @AuthenticationPrincipal 방식으로 전환되면 apiFetch 내부에서 memberId 자동 추가 로직 제거 예정입니다.