### PR TITLE
refactor/fix: 메뉴 등록 및 수정 API 연동 개선, 주문 목록 에러 처리 추가

### DIFF
--- a/frontend/src/app/admin/menus/[id]/page.tsx
+++ b/frontend/src/app/admin/menus/[id]/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
+import { apiFetch } from "@/lib/apiFetch"; // apiFetch 임포트
 
 type Props = {
   params: { id: string };
@@ -21,15 +22,14 @@ export default function EditMenu({ params }: Props) {
   // 메뉴 상세 조회 → 기존 데이터 불러오기
   const fetchMenu = async () => {
     try {
-      const res = await fetch(`http://localhost:8080/admin/menus/${menuId}`);
-      if (!res.ok) throw new Error("메뉴 불러오기 실패");
+      const res = await apiFetch(`/admin/menus/${menuId}`);
+      // 응답에서 data 필드를 통해 메뉴 정보 가져오기
+      const menuData = res.data; 
 
-      const data = await res.json();
-
-      setName(data.name);
-      setDescription(data.description);
-      setPrice(data.price);
-      setStockCount(data.stock_count);
+      setName(menuData.name);
+      setDescription(menuData.description);
+      setPrice(menuData.price);
+      setStockCount(menuData.stock_count); // snake_case → camelCase로 처리
     } catch (error) {
       console.error(error);
       alert("메뉴 정보를 불러오는 중 오류가 발생했습니다.");
@@ -50,24 +50,18 @@ export default function EditMenu({ params }: Props) {
       name,
       description,
       price,
-      stock_count: stockCount,
+      stockCount,
     };
 
     try {
-      const res = await fetch(`http://localhost:8080/admin/menus/${menuId}`, {
+      const res = await apiFetch(`/admin/menus/${menuId}`, {
         method: "PUT",
-        headers: {
-          "Content-Type": "application/json",
-        },
         body: JSON.stringify(updatedMenu),
+        headers: { "Content-Type": "application/json" },
       });
 
-      if (!res.ok) throw new Error("메뉴 수정 실패");
-
-      // 수정된 메뉴 응답 받기
-      const updated = await res.json();
       alert(
-        `메뉴가 수정되었습니다!\n\n 수정 결과:\n- 이름: ${updated.name}\n- 설명: ${updated.description}\n- 가격: ${updated.price}원\n- 재고: ${updated.stock_count}개`
+        `메뉴가 수정되었습니다!\n\n 수정 결과:\n- 이름: ${res.name}\n- 설명: ${res.description}\n- 가격: ${res.price}원\n- 재고: ${res.stock_count}개`
       );
 
       router.push("/admin/menus"); // 수정 후 목록으로 이동

--- a/frontend/src/app/admin/menus/[id]/page.tsx
+++ b/frontend/src/app/admin/menus/[id]/page.tsx
@@ -24,7 +24,7 @@ export default function EditMenu({ params }: Props) {
     try {
       const res = await apiFetch(`/admin/menus/${menuId}`);
       // 응답에서 data 필드를 통해 메뉴 정보 가져오기
-      const menuData = res.data; 
+      const menuData = res.data;
 
       setName(menuData.name);
       setDescription(menuData.description);
@@ -50,7 +50,7 @@ export default function EditMenu({ params }: Props) {
       name,
       description,
       price,
-      stockCount,
+      stock_count: stockCount,
     };
 
     try {
@@ -61,7 +61,7 @@ export default function EditMenu({ params }: Props) {
       });
 
       alert(
-        `메뉴가 수정되었습니다!\n\n 수정 결과:\n- 이름: ${res.name}\n- 설명: ${res.description}\n- 가격: ${res.price}원\n- 재고: ${res.stock_count}개`
+        `메뉴가 수정되었습니다!\n\n 수정 결과:\n- 이름: ${res.data.name}\n- 설명: ${res.data.description}\n- 가격: ${res.data.price}원\n- 재고: ${res.data.stock_count}개`
       );
 
       router.push("/admin/menus"); // 수정 후 목록으로 이동

--- a/frontend/src/app/admin/menus/page.tsx
+++ b/frontend/src/app/admin/menus/page.tsx
@@ -176,7 +176,7 @@ export default function Menus() {
                   {/* 삭제 버튼 */}
                   <button
                     onClick={() => handleDeleteMenu(menu.id)}
-                    className="px-2 py-1 bg-gray-500 text-white hover:bg-gray-400"
+                    className="px-2 py-1 bg-gray-300 hover:bg-gray-400"
                   >
                     삭제
                   </button>

--- a/frontend/src/app/admin/menus/page.tsx
+++ b/frontend/src/app/admin/menus/page.tsx
@@ -61,7 +61,7 @@ export default function Menus() {
           name,
           description,
           price,
-          stockCount,
+          stock_count: stockCount, // stockCount → stock_count로 수정
         }),
         headers: { "Content-Type": "application/json" },
       });

--- a/frontend/src/app/admin/orders/page.tsx
+++ b/frontend/src/app/admin/orders/page.tsx
@@ -1,47 +1,21 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { Order, OrderItem } from "@/types"; // 공용 타입 사용
+import { Order, OrderItem } from "@/types";
+import { apiFetch } from "@/lib/apiFetch";
 
 export default function Orders() {
   const [orders, setOrders] = useState<Order[]>([]);
   const [loading, setLoading] = useState(true);
 
-  // ✅ 테스트용 더미 데이터
-  const dummyOrders: Order[] = [
-    {
-      orderId: 1001,
-      userId: 1,
-      email: "coffee@lover.com",
-      createdAt: "2025-07-16T10:30:00",
-      totalPrice: 18500,
-      orderItems: [
-        { menuId: 1, name: "아메리카노", quantity: 2, price: 5000 },
-        { menuId: 2, name: "카페라떼", quantity: 1, price: 8500 },
-      ],
-    },
-    {
-      orderId: 1002,
-      userId: 2,
-      email: "latte@cafe.com",
-      createdAt: "2025-07-16T11:15:00",
-      totalPrice: 12000,
-      orderItems: [
-        { menuId: 3, name: "카푸치노", quantity: 2, price: 6000 },
-      ],
-    },
-  ];
-
   const fetchOrders = async () => {
     try {
-      const res = await fetch("http://localhost:8080/admin/orders");
-      if (!res.ok) throw new Error("주문 목록 불러오기 실패");
-
-      const data: Order[] = await res.json();
+      const response = await apiFetch<any>("/admin/orders");
+      const data: Order[] = response.data || response; // 백엔드 응답 형태에 따라 조정
       setOrders(data);
     } catch (error) {
-      console.error("API 실패 → 더미 데이터 사용");
-      setOrders(dummyOrders); // ❗ 실패 시 더미데이터 사용
+      console.error("주문 목록 불러오기 실패", error);
+      alert("주문 데이터를 불러오는 데 실패했습니다.");
     } finally {
       setLoading(false);
     }


### PR DESCRIPTION
## 📌 과제 설명
관리자 페이지에서 메뉴 등록, 수정, 삭제 및 주문 목록 조회 기능을 백엔드 API와 연동

## 👩‍💻 요구 사항과 구현 내용
1. 메뉴 등록 시 stockCount 수정
2. 메뉴 수정 시 stockCount 수정
3. 주문 목록 API 호출 방식 수정
- 기존에 fetch로 API 요청하던 방식을 apiFetch로 변경
4. 관리자 메뉴 삭제 버튼 색상을 공통 디자인 컬러 적용

## ✅ PR 포인트 & 궁금한 점 
1. 메뉴 등록 및 수정 시 stock_count 처리: stockCount와 stock_count를 일치시켜서 백엔드 호환성 문제 해결
2. API 호출 개선: apiFetch로 통합