### PR TITLE
feat: 주문 내역 페이지에 페이징 기능 추가 + 페이지네이션 UI 개선

### DIFF
--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -4,10 +4,9 @@ import { useState } from "react";
 import { useLogin } from "@/_hooks/useLogin";
 import { LoginForm } from "@/types";
 import { InputField } from "@/_components/ui/InputField";
-import { ErrorMessage } from "@/_components/ui/ErrorMessage";
 
 export default function LoginPage() {
-  const { login, isLoading, errorMessage } = useLogin();
+  const { login, isLoading } = useLogin();
   const [form, setForm] = useState<LoginForm>({ email: "", password: "" });
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -49,8 +48,6 @@ export default function LoginPage() {
           >
             {isLoading ? "로그인 중..." : "로그인"}
           </button>
-
-          <ErrorMessage message={errorMessage} />
         </form>
       </div>
     </div>

--- a/frontend/src/app/mypage/page.tsx
+++ b/frontend/src/app/mypage/page.tsx
@@ -1,17 +1,64 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { useRouter } from "next/navigation";
-import { apiFetch } from "@/lib/apiFetch"; 
+import { useRouter, useSearchParams } from "next/navigation";
+import { apiFetch } from "@/lib/apiFetch";
 import { Order } from "@/types";
 import { OrderCard } from "@/_components/mypage/OrderCard";
 import { useAuth } from "@/_hooks/auth-context";
 import { toast } from "react-toastify";
 
+// 페이징 응답 타입
+type PagedResponse<T> = {
+  content: T[];
+  totalPages: number;
+  totalElements: number;
+  number: number;
+  size: number;
+};
+
+// 페이지네이션 범위 계산 함수
+function getCompactPagination(current: number, total: number): (number | "...")[] {
+  if (total <= 3) {
+    return Array.from({ length: total }, (_, i) => i + 1); // 1, 2, 3
+  }
+
+  const result: (number | "...")[] = [1];
+
+  if (current > 2) {
+    result.push("...");
+  }
+
+  if (current !== 1 && current !== total) {
+    result.push(current);
+  }
+
+  if (current < total - 1) {
+    result.push("...");
+  }
+
+  if (total !== 1) {
+    result.push(total);
+  }
+
+  return result;
+}
+
 export default function MyPage() {
-  const [orders, setOrders] = useState<Order[]>([]);
   const router = useRouter();
+  const searchParams = useSearchParams();
   const { isLoggedIn } = useAuth();
+
+  const initialPage = Number(searchParams.get("page")) || 0;
+
+  const [page, setPage] = useState(initialPage);
+  const [orders, setOrders] = useState<Order[]>([]);
+  const [totalPages, setTotalPages] = useState(0);
+
+  // URL 동기화
+  useEffect(() => {
+    router.replace(`/mypage?page=${page}`);
+  }, [page, router]);
 
   useEffect(() => {
     if (!isLoggedIn) {
@@ -20,29 +67,88 @@ export default function MyPage() {
       return;
     }
 
-    // API 호출
-    apiFetch<Order[]>("/myorder")
+    apiFetch<PagedResponse<Order>>(`/myorder?page=${page}&size=10`)
       .then((data) => {
-        const sorted = data.sort( // 최신 순 정렬
-          (a, b) =>
-            new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
-        );
-        setOrders(sorted);
+        setOrders(data.content);
+        setTotalPages(data.totalPages);
       })
       .catch((err) => {
         toast.error("주문 내역 불러오기 실패: " + err.message);
       });
-  }, [isLoggedIn, router]);
+  }, [isLoggedIn, page, router]);
 
   return (
     <div className="p-6 max-w-4xl mx-auto">
       <h1 className="text-2xl font-bold mb-6">내 주문 내역</h1>
 
       <div className="flex flex-col gap-6 max-h-[80vh] overflow-y-auto pr-2">
-        {orders.map((order) => (
-          <OrderCard key={order.orderId} order={order} />
-        ))}
+        {orders.length === 0 ? (
+          <div className="text-center text-gray-500 mt-6">
+            아직 주문 내역이 없습니다. <br />
+            메뉴를 주문해보세요!
+          </div>
+        ) : (
+          orders.map((order) => (
+            <OrderCard key={order.orderId} order={order} />
+          ))
+        )}
       </div>
+
+      {/* 페이지네이션 */}
+      {totalPages > 1 && (
+        <div className="flex flex-col items-center gap-2 mt-6">
+          <div className="flex gap-1">
+            {/* 이전 버튼 */}
+            <button
+              onClick={() => setPage((prev) => Math.max(prev - 1, 0))}
+              disabled={page === 0}
+              className="px-3 py-1 border rounded disabled:opacity-50 text-sm"
+            >
+              ◀
+            </button>
+
+            {/* 페이지 번호 */}
+            {getCompactPagination(page + 1, totalPages).map((item, idx) => {
+              if (item === "...") {
+                return (
+                  <span
+                    key={idx}
+                    className="px-2 py-1 text-gray-500 text-sm select-none"
+                  >
+                    ...
+                  </span>
+                );
+              }
+
+              const pageIndex = item - 1;
+              const isActive = pageIndex === page;
+
+              return (
+                <button
+                  key={idx}
+                  onClick={() => setPage(pageIndex)}
+                  className={`px-3 py-1 rounded border text-sm ${
+                    isActive
+                      ? "bg-black text-white"
+                      : "bg-white text-black hover:bg-gray-100"
+                  }`}
+                >
+                  {item}
+                </button>
+              );
+            })}
+
+            {/* 다음 버튼 */}
+            <button
+              onClick={() => setPage((prev) => Math.min(prev + 1, totalPages - 1))}
+              disabled={page === totalPages - 1}
+              className="px-3 py-1 border rounded disabled:opacity-50 text-sm"
+            >
+              ▶
+            </button>
+          </div>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
### 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
로그인 페이지의 에러 메세지 오류를 해결했습니다. 
백엔드의 페이징 작업을 받아서 프론트에도 페이징 기능을 연동했습니다. 페이지네이션 UI도 함께 개선했습니다.

### 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
- `GET /myorder` 요청에 페이지 파라미터(`page`, `size`) 전달
- 서버 응답을 `PagedResponse<T>` 타입으로 받도록 구현
- `page.tsx`
  - 로그인 상태 확인 후 주문 내역 조회
  - 페이지네이션 동기화 (URL에 ?page=N 반영) 
  - 페이지가 많은 경우 `1 ... 현재 ... 마지막` 형태의 단순 페이지네이션 구현
- Tailwind로 페이지 버튼 스타일링 및 현재 페이지 강조 처리
- 주문이 없는 경우 사용자에게 메시지 표시

### ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
페이지네이션 UI를 최소화된 방식으로 표현했는데, 혹시 더 직관적인 UI나 UX 방향이 있다면 피드백 부탁드립니다.