### PR TITLE
feat: 관리자 주문/메뉴 기능 개선 및 이미지 필드 처리 추가

### DIFF
--- a/backend/src/main/java/com/back/domain/menu/menu/dto/MenuDto.java
+++ b/backend/src/main/java/com/back/domain/menu/menu/dto/MenuDto.java
@@ -8,7 +8,9 @@ public record MenuDto(
         String description,
         @Min(0) int price,
         @Min(0) int stock_count,
-        String category
+        String category,
+        String imageUrl,
+        String imageName
 ) {
     public Menu toEntity() {
         return new Menu(name, description, price, stock_count, category);

--- a/backend/src/main/java/com/back/domain/menu/menu/dto/MenuDto.java
+++ b/backend/src/main/java/com/back/domain/menu/menu/dto/MenuDto.java
@@ -13,6 +13,6 @@ public record MenuDto(
         String imageName
 ) {
     public Menu toEntity() {
-        return new Menu(name, description, price, stock_count, category);
+        return new Menu(name, description, price, stock_count, category, imageUrl, imageName);
     }
 }

--- a/backend/src/main/java/com/back/domain/menu/menu/entity/Menu.java
+++ b/backend/src/main/java/com/back/domain/menu/menu/entity/Menu.java
@@ -20,19 +20,25 @@ public class Menu extends BaseEntity {
     private String imageName;     // 원본 파일명
     private String category;
 
-    public Menu(String name, String description, int price, int stock_count, String category) {
+    // 모든 필드를 포함한 생성자 추가
+    public Menu(String name, String description, int price, int stock_count, String category, String imageUrl, String imageName) {
         this.name = name;
         this.description = description;
         this.price = price;
         this.stock_count = stock_count;
         this.category = category;
+        this.imageUrl = imageUrl;
+        this.imageName = imageName;
     }
 
-    public void update(MenuDto dto){
+    // DTO 기반 업데이트 시 모든 필드 반영
+    public void update(MenuDto dto) {
         this.name = dto.name();
         this.description = dto.description();
         this.price = dto.price();
         this.stock_count = dto.stock_count();
+        this.imageUrl = dto.imageUrl();
+        this.imageName = dto.imageName();
     }
 
     // 재고 감소

--- a/backend/src/main/java/com/back/global/initData/OrderInitData.java
+++ b/backend/src/main/java/com/back/global/initData/OrderInitData.java
@@ -23,76 +23,42 @@ public class OrderInitData {
     private final OrderRepository orderRepository;
     private final PasswordEncoder passwordEncoder;
 
-    // 기본 입력 데이터입니다.
+    private static final String IMAGE_URL = "/images/test1.jpg";
+    private static final String IMAGE_NAME = "test1.jpg";
 
     @EventListener(ApplicationReadyEvent.class)
     @Transactional
     public void init() {
-        // 중복 체크: 이미 admin 계정이 있으면 초기화 하지 않음
         if (memberRepository.findByEmail("admin1@test.com").isPresent()) {
             System.out.println("초기 데이터가 이미 존재합니다. 스킵합니다.");
             return;
         }
 
-        // 1. 메뉴 등록
-        Menu americano = menuRepository.save(new Menu("아메리카노", "아메리카노 입니다", 3000, 200, "커피"));
-        Menu latte = menuRepository.save(new Menu("카페라떼", "카페라떼입니다", 4000, 200, "커피"));
-        Menu mocha = menuRepository.save(new Menu("카페모카", "달콤한 초콜릿이 들어간 카페모카입니다", 4500, 150, "커피"));
-        Menu vanillaLatte = menuRepository.save(new Menu("바닐라라떼", "향긋한 바닐라 시럽이 들어간 라떼입니다", 4500, 180, "커피"));
-        Menu espresso = menuRepository.save(new Menu("에스프레소", "진한 원두의 향을 즐길 수 있는 에스프레소입니다", 2500, 100, "커피"));
+        // 메뉴 등록
+        Menu americano = menuRepository.save(new Menu("아메리카노", "아메리카노 입니다", 3000, 200, "커피", IMAGE_URL, IMAGE_NAME));
+        Menu latte = menuRepository.save(new Menu("카페라떼", "카페라떼입니다", 4000, 200, "커피", IMAGE_URL, IMAGE_NAME));
+        Menu mocha = menuRepository.save(new Menu("카페모카", "달콤한 초콜릿이 들어간 카페모카입니다", 4500, 150, "커피", IMAGE_URL, IMAGE_NAME));
+        Menu vanillaLatte = menuRepository.save(new Menu("바닐라라떼", "향긋한 바닐라 시럽이 들어간 라떼입니다", 4500, 180, "커피", IMAGE_URL, IMAGE_NAME));
+        Menu espresso = menuRepository.save(new Menu("에스프레소", "진한 원두의 향을 즐길 수 있는 에스프레소입니다", 2500, 100, "커피", IMAGE_URL, IMAGE_NAME));
 
-        Menu kenya = menuRepository.save(new Menu(
-                "케냐AA",
-                "케냐산 원두의 강렬한 산미와 깊은 풍미",
-                4800,
-                120,
-                "원두"
-        ));
+        Menu kenya = menuRepository.save(new Menu("케냐AA", "케냐산 원두의 강렬한 산미와 깊은 풍미", 4800, 120, "원두", IMAGE_URL, IMAGE_NAME));
+        Menu ethiopia = menuRepository.save(new Menu("에티오피아 예가체프", "꽃향기와 과일향이 어우러진 에티오피아산 스페셜 원두", 5000, 110, "원두", IMAGE_URL, IMAGE_NAME));
+        Menu colombia = menuRepository.save(new Menu("콜롬비아 수프리모", "밸런스가 좋은 콜롬비아 원두", 4500, 130, "원두", IMAGE_URL, IMAGE_NAME));
+        Menu brazil = menuRepository.save(new Menu("브라질 산토스", "고소하고 묵직한 바디감의 브라질산 원두", 4300, 100, "원두", IMAGE_URL, IMAGE_NAME));
+        Menu guatemala = menuRepository.save(new Menu("과테말라 안티구아", "스모키한 향과 깊은 단맛이 매력적인 과테말라 원두", 4700, 90, "원두", IMAGE_URL, IMAGE_NAME));
 
-        Menu ethiopia = menuRepository.save(new Menu(
-                "에티오피아 예가체프",
-                "꽃향기와 과일향이 어우러진 에티오피아산 스페셜 원두",
-                5000,
-                110,
-                "원두"
-        ));
+        Menu ade = menuRepository.save(new Menu("레몬에이드", "상큼한 레몬이 톡 쏘는 에이드입니다", 3800, 120, "음료", IMAGE_URL, IMAGE_NAME));
+        Menu milkTea = menuRepository.save(new Menu("타로 밀크티", "달콤한 타로와 부드러운 밀크티의 조화", 4200, 130, "음료", IMAGE_URL, IMAGE_NAME));
+        Menu matchaLatte = menuRepository.save(new Menu("말차 라떼", "쌉쌀한 말차가 들어간 건강한 라떼", 4300, 90, "음료", IMAGE_URL, IMAGE_NAME));
 
-        Menu colombia = menuRepository.save(new Menu(
-                "콜롬비아 수프리모",
-                "밸런스가 좋은 콜롬비아 원두",
-                4500,
-                130,
-                "원두"
-        ));
+        Menu tiramisu = menuRepository.save(new Menu("티라미수", "부드러운 마스카포네 크림이 가득한 티라미수", 5000, 50, "디저트", IMAGE_URL, IMAGE_NAME));
+        Menu macaron = menuRepository.save(new Menu("마카롱 세트", "색색의 달콤한 마카롱 6종 세트", 7000, 30, "디저트", IMAGE_URL, IMAGE_NAME));
+        Menu cheesecake = menuRepository.save(new Menu("뉴욕 치즈케이크", "진한 크림치즈 맛의 클래식 치즈케이크", 5500, 40, "디저트", IMAGE_URL, IMAGE_NAME));
 
-        Menu brazil = menuRepository.save(new Menu(
-                "브라질 산토스",
-                "고소하고 묵직한 바디감의 브라질산 원두",
-                4300,
-                100,
-                "원두"
-        ));
+        Menu hamSandwich = menuRepository.save(new Menu("햄치즈 샌드위치", "햄과 치즈가 조화로운 클래식 샌드위치", 4800, 60, "샌드위치", IMAGE_URL, IMAGE_NAME));
+        Menu chickenWrap = menuRepository.save(new Menu("치킨 랩", "닭가슴살과 채소가 듬뿍 들어간 건강한 랩", 5200, 45, "샌드위치", IMAGE_URL, IMAGE_NAME));
 
-        Menu guatemala = menuRepository.save(new Menu(
-                "과테말라 안티구아",
-                "스모키한 향과 깊은 단맛이 매력적인 과테말라 원두",
-                4700,
-                90,
-                "원두"
-        ));
-
-        Menu ade = menuRepository.save(new Menu("레몬에이드", "상큼한 레몬이 톡 쏘는 에이드입니다", 3800, 120, "음료"));
-        Menu milkTea = menuRepository.save(new Menu("타로 밀크티", "달콤한 타로와 부드러운 밀크티의 조화", 4200, 130, "음료"));
-        Menu matchaLatte = menuRepository.save(new Menu("말차 라떼", "쌉쌀한 말차가 들어간 건강한 라떼", 4300, 90, "음료"));
-
-        Menu tiramisu = menuRepository.save(new Menu("티라미수", "부드러운 마스카포네 크림이 가득한 티라미수", 5000, 50, "디저트"));
-        Menu macaron = menuRepository.save(new Menu("마카롱 세트", "색색의 달콤한 마카롱 6종 세트", 7000, 30, "디저트"));
-        Menu cheesecake = menuRepository.save(new Menu("뉴욕 치즈케이크", "진한 크림치즈 맛의 클래식 치즈케이크", 5500, 40, "디저트"));
-
-        Menu hamSandwich = menuRepository.save(new Menu("햄치즈 샌드위치", "햄과 치즈가 조화로운 클래식 샌드위치", 4800, 60, "샌드위치"));
-        Menu chickenWrap = menuRepository.save(new Menu("치킨 랩", "닭가슴살과 채소가 듬뿍 들어간 건강한 랩", 5200, 45, "샌드위치"));
-
-        // 2. 사용자 등록
+        // 사용자 등록
         Member user1 = new Member("admin1@test.com", passwordEncoder.encode("123456"), "admin1", "서울시 어드민 주소", Role.ADMIN);
         Member user2 = new Member("user1@test.com", passwordEncoder.encode("123456"), "user1", "서울시 강남구");
         Member user3 = new Member("user2@test.com", passwordEncoder.encode("123456"), "user2", "서울시 마포구");
@@ -103,8 +69,7 @@ public class OrderInitData {
         memberRepository.save(user3);
         memberRepository.save(user4);
 
-
-        // 3. 주문 등록 (admin1의 주문, 25개 (편의를 위해 admin1로 했습니다.))
+        // 주문 등록
         for (int i = 1; i <= 25; i++) {
             Order order = new Order();
             order.setMember(user1); // admin1
@@ -128,7 +93,6 @@ public class OrderInitData {
 
             orderRepository.save(order);
         }
-
 
         System.out.println("초기 데이터 삽입 완료");
     }

--- a/frontend/src/_hooks/useLogin.ts
+++ b/frontend/src/_hooks/useLogin.ts
@@ -30,6 +30,9 @@ export function useLogin() {
     try {
       await apiFetch("/login", {
         method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
         body: JSON.stringify(form),
       });
 

--- a/frontend/src/_hooks/useOrder.ts
+++ b/frontend/src/_hooks/useOrder.ts
@@ -29,6 +29,9 @@ export function useOrder() {
     try {
       await apiFetch("/orders", {
         method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
         body: JSON.stringify({ orderItems: items }),
       });
 

--- a/frontend/src/_hooks/useSignup.ts
+++ b/frontend/src/_hooks/useSignup.ts
@@ -30,6 +30,9 @@ export function useSignup() {
     try {
       await apiFetch("/signup", {
         method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
         body: JSON.stringify(form),
       });
 

--- a/frontend/src/app/admin/menus/[id]/page.tsx
+++ b/frontend/src/app/admin/menus/[id]/page.tsx
@@ -51,7 +51,7 @@ export default function EditMenu({ params }: Props) {
       name,
       description,
       price,
-      stockCount,
+      stock_count: stockCount,
     };
 
     try {

--- a/frontend/src/app/admin/menus/[id]/page.tsx
+++ b/frontend/src/app/admin/menus/[id]/page.tsx
@@ -51,7 +51,7 @@ export default function EditMenu({ params }: Props) {
       name,
       description,
       price,
-      stock_count: stockCount,
+      stockCount,
     };
 
     try {

--- a/frontend/src/app/admin/menus/[id]/page.tsx
+++ b/frontend/src/app/admin/menus/[id]/page.tsx
@@ -18,6 +18,8 @@ export default function EditMenu({ params }: Props) {
   const [description, setDescription] = useState("");
   const [price, setPrice] = useState<number>(0);
   const [stockCount, setStockCount] = useState<number>(0);
+  const [imageUrl, setImageUrl] = useState("");
+  const [imageName, setImageName] = useState("");
   const [loading, setLoading] = useState(true);
 
   // 메뉴 상세 조회 → 기존 데이터 불러오기
@@ -27,10 +29,12 @@ export default function EditMenu({ params }: Props) {
       // 응답에서 data 필드를 통해 메뉴 정보 가져오기
       const menuData = res.data;
 
-      setName(menuData.name);
-      setDescription(menuData.description);
-      setPrice(menuData.price);
-      setStockCount(menuData.stock_count); // snake_case → camelCase로 처리
+      setName(menuData.name || "");
+      setDescription(menuData.description || "");
+      setPrice(menuData.price || 0);
+      setStockCount(menuData.stock_count || 0); // snake_case → camelCase로 처리
+      setImageUrl(menuData.imageUrl || "");
+      setImageName(menuData.imageName || "");
     } catch (error) {
       console.error(error);
       toast.error("메뉴 정보를 불러오는 중 오류가 발생했습니다."); // toastify로 오류 알림
@@ -52,13 +56,17 @@ export default function EditMenu({ params }: Props) {
       description,
       price,
       stock_count: stockCount,
+      imageUrl,
+      imageName,
     };
 
     try {
       const res = await apiFetch(`/admin/menus/${menuId}`, {
         method: "PUT",
+        headers: {
+          "Content-Type": "application/json",
+        },
         body: JSON.stringify(updatedMenu),
-        headers: { "Content-Type": "application/json" },
       });
 
       toast.success(`메뉴가 수정되었습니다!\n- 이름: ${res.data.name}\n- 가격: ${res.data.price}원`); // 수정 성공 알림
@@ -117,6 +125,28 @@ export default function EditMenu({ params }: Props) {
               value={stockCount}
               onChange={(e) => setStockCount(Number(e.target.value))}
               placeholder="재고 수량을 입력하세요"
+            />
+          </div>
+
+          <div>
+            <label className="block text-lg font-semibold">이미지 URL</label>
+            <input
+              type="text"
+              className="w-full border p-2 rounded"
+              value={imageUrl}
+              onChange={(e) => setImageUrl(e.target.value)}
+              placeholder="/images/latte.jpg"
+            />
+          </div>
+
+          <div>
+            <label className="block text-lg font-semibold">이미지 이름</label>
+            <input
+              type="text"
+              className="w-full border p-2 rounded"
+              value={imageName}
+              onChange={(e) => setImageName(e.target.value)}
+              placeholder="latte.jpg"
             />
           </div>
 

--- a/frontend/src/app/admin/menus/page.tsx
+++ b/frontend/src/app/admin/menus/page.tsx
@@ -20,6 +20,8 @@ export default function Menus() {
   const [description, setDescription] = useState("");
   const [price, setPrice] = useState<number>(0);
   const [stockCount, setStockCount] = useState<number>(0);
+  const [imageUrl, setImageUrl] = useState("");     // ✅ 추가
+  const [imageName, setImageName] = useState("");   // ✅ 추가
 
   const fetchMenus = async () => {
     try {
@@ -62,7 +64,9 @@ export default function Menus() {
           name,
           description,
           price,
-          stock_count: stockCount, // stockCount → stock_count로 수정
+          stock_count: stockCount,
+          imageUrl,
+          imageName,
         }),
         headers: { "Content-Type": "application/json" },
       });
@@ -192,7 +196,6 @@ export default function Menus() {
                   className="w-full border p-2 rounded"
                   value={price}
                   onChange={(e) => setPrice(Number(e.target.value))}
-                  placeholder="가격을 입력하세요"
                 />
               </div>
 
@@ -203,7 +206,28 @@ export default function Menus() {
                   className="w-full border p-2 rounded"
                   value={stockCount}
                   onChange={(e) => setStockCount(Number(e.target.value))}
-                  placeholder="재고 수량을 입력하세요"
+                />
+              </div>
+
+              <div>
+                <label className="block font-semibold">이미지 URL</label>
+                <input
+                  type="text"
+                  className="w-full border p-2 rounded"
+                  value={imageUrl}
+                  onChange={(e) => setImageUrl(e.target.value)}
+                  placeholder="/images/latte.jpg"
+                />
+              </div>
+
+              <div>
+                <label className="block font-semibold">이미지 이름</label>
+                <input
+                  type="text"
+                  className="w-full border p-2 rounded"
+                  value={imageName}
+                  onChange={(e) => setImageName(e.target.value)}
+                  placeholder="latte.jpg"
                 />
               </div>
 

--- a/frontend/src/app/admin/menus/page.tsx
+++ b/frontend/src/app/admin/menus/page.tsx
@@ -58,17 +58,25 @@ export default function Menus() {
     e.preventDefault();
 
     try {
+      const formData = new FormData();
+      
+      const menuData = {
+        name,
+        description,
+        price,
+        stock_count: stockCount,
+        imageUrl,
+        imageName,
+      };
+      
+      // menu part를 JSON blob으로 추가
+      formData.append("menu", new Blob([JSON.stringify(menuData)], {
+        type: "application/json"
+      }));
+
       await apiFetch("/admin/addmenu", {
         method: "POST",
-        body: JSON.stringify({
-          name,
-          description,
-          price,
-          stock_count: stockCount,
-          imageUrl,
-          imageName,
-        }),
-        headers: { "Content-Type": "application/json" },
+        body: formData,
       });
 
       toast.success("메뉴가 등록되었습니다.");  // 성공 메시지

--- a/frontend/src/app/admin/menus/page.tsx
+++ b/frontend/src/app/admin/menus/page.tsx
@@ -80,6 +80,15 @@ export default function Menus() {
       });
 
       toast.success("메뉴가 등록되었습니다.");  // 성공 메시지
+      
+      // 폼 데이터 초기화
+      setName("");
+      setDescription("");
+      setPrice(0);
+      setStockCount(0);
+      setImageUrl("");
+      setImageName("");
+      
       closeModal(); // 모달 닫기
       fetchMenus(); // 등록 후 목록 새로고침
     } catch (error) {

--- a/frontend/src/app/admin/menus/page.tsx
+++ b/frontend/src/app/admin/menus/page.tsx
@@ -34,6 +34,8 @@ export default function Menus() {
         description: menu.description,
         price: menu.price,
         stockCount: menu.stock_count, // snake_case → camelCase
+        imageUrl: menu.imageUrl,
+        imageName: menu.imageName,
       }));
 
       setMenus(formattedMenus);
@@ -139,6 +141,7 @@ export default function Menus() {
           <thead className="bg-black text-white font-bold tracking-wide uppercase h-12 border-b border-gray-300 rounded">
             <tr>
               <th className="px-4 py-2 text-left">ID</th>
+              <th className="px-4 py-2 text-left">이미지</th>
               <th className="px-4 py-2 text-left">이름</th>
               <th className="px-4 py-2 text-left">설명</th>
               <th className="px-4 py-2 text-left">가격</th>
@@ -150,6 +153,25 @@ export default function Menus() {
             {menus.map((menu) => (
               <tr key={menu.id} className="hover:bg-gray-50 transition-colors">
                 <td className="px-4 py-3 text-left font-medium">{menu.id}</td>
+                <td className="px-4 py-3 text-left">
+                  {menu.imageUrl ? (
+                    <img 
+                      src={menu.imageUrl} 
+                      alt={menu.imageName || menu.name}
+                      className="w-12 h-12 object-cover rounded"
+                      onError={(e) => {
+                        e.currentTarget.style.display = 'none';
+                        e.currentTarget.nextElementSibling.style.display = 'block';
+                      }}
+                    />
+                  ) : null}
+                  <span 
+                    className="text-gray-400 text-sm" 
+                    style={{display: menu.imageUrl ? 'none' : 'block'}}
+                  >
+                    이미지 없음
+                  </span>
+                </td>
                 <td className="px-4 py-3 text-left">{menu.name}</td>
                 <td className="px-4 py-3 text-left">{menu.description}</td>
                 <td className="px-4 py-3 text-right">

--- a/frontend/src/app/admin/orders/page.tsx
+++ b/frontend/src/app/admin/orders/page.tsx
@@ -12,8 +12,8 @@ export default function Orders() {
   const fetchOrders = async () => {
     try {
       const response = await apiFetch<any>("/admin/orders");
-      const data: Order[] = response.data || response; // 백엔드 응답 형태에 따라 조정
-      setOrders(data);
+      const data = response.data || response;; // 백엔드 응답 형태에 따라 조정
+      setOrders(data.content);
     } catch (error) {
       console.error("주문 목록 불러오기 실패", error);
       toast.error("주문 데이터를 불러오는 데 실패했습니다.");  // toastify로 에러 표시

--- a/frontend/src/app/admin/orders/page.tsx
+++ b/frontend/src/app/admin/orders/page.tsx
@@ -38,7 +38,7 @@ export default function Orders() {
       </h1>
       <div className="overflow-x-auto border border-gray-300 rounded">
         <table className="w-full table-auto text-sm text-left text-black bg-white rounded">
-          <thead className="bg-black text-white text font-bold tracking-wide uppercase h-12 rounded">
+          <thead className="bg-black text-white font-bold tracking-wide uppercase h-12 rounded">
             <tr>
               <th className="px-4 py-2 text-center">주문번호</th>
               <th className="px-4 py-2 text-center">주문일시</th>

--- a/frontend/src/lib/apiFetch.ts
+++ b/frontend/src/lib/apiFetch.ts
@@ -8,7 +8,6 @@ export async function apiFetch<T>(
   const res = await fetch(`${baseUrl}${url}`, {
     ...options,
     headers: {
-      "Content-Type": "application/json",
       ...(options.headers || {}),
     },
     credentials: "include",

--- a/frontend/src/types/menu.ts
+++ b/frontend/src/types/menu.ts
@@ -4,6 +4,8 @@ export type Menu = {
   description: string;
   price: number;
   stockCount?: number; // stockCount는 관리자 메뉴에서만 사용, 일반 메뉴에는 없어도 됨
+  imageUrl?: string; // 이미지 URL
+  imageName?: string; // 이미지 이름
 };
 
 export type MenuItem = {


### PR DESCRIPTION
## 📌 과제 설명
1. 사용자 페이지에서 제공하던 UX 및 기능적 편의를 관리자 페이지에도 반영
2. 메뉴 등록/수정 기능에 이미지 업로드 및 데이터 연동을 추가
3. 초기 데이터에도 공통 이미지를 적용

## ✨ 주요 변경 사항
### ✅ 메뉴 등록/수정 기능 개선
- `MenuDto`에 이미지 URL / 이미지 이름 필드 추가
- 등록 시 `FormData` 형식 전송 + 이미지 정보 포함
- 메뉴 등록 후 입력폼 초기화 로직 추가
- 수정 시에도 이미지 정보 수정 가능하도록 페이지 연동
- `Menu.toEntity()`, `update()`에 이미지 필드 포함

### ✅ UI 스타일 개선
- 테이블 및 버튼에 `rounded` 클래스 적용
- `text-[13px]` 클래스 제거 → 폰트 크기 기본화

### ✅ API 호출 구조 개선
- `apiFetch` 기본 Content-Type 제거 → FormData 처리 대응
- 필요 시 명시적으로 `Content-Type` 설정


## 🧪 초기 데이터 개선
- `OrderInitData`에 메뉴 20여 개 등록
- 모든 메뉴에 공통 이미지(`test1.jpg`, `/images/test1.jpg`) 삽입 (`90a636e`)
- `admin1@test.com` 계정 기준으로 주문 25건 생성


## 🛠 Merge 관련
- rebase 중 발생한 충돌 해결 완료


## ✅ 리뷰 시 참고 사항
- FormData 관련으로  apiFetch파일에서 `apiFetch` 기본 Content-Type 제거했습니다. 이로인해 Content-Type이 설정되지 않아서 브라우저가 기본값인 text/plain;charset=UTF-8을 사용하게 되어서 필요한 곳에 명시적으로 Content-Type: application/json 설정을 추가해야했습니다.
  - 메뉴 등록: FormData 사용 (multipart/form-data, Content-Type 자동 설정)
  - 다른 JSON 요청들: 명시적으로 Content-Type: application/json 설정
