### PR TITLE
feat: 전역 장바구니 상태 관리 

### DIFF
--- a/frontend/src/_contexts/CartContext.tsx
+++ b/frontend/src/_contexts/CartContext.tsx
@@ -1,0 +1,63 @@
+// src/_contexts/CartContext.tsx
+"use client";
+
+import { createContext, useContext, useEffect, useState } from "react";
+import { CartItem } from "@/types";
+
+type CartContextType = {
+  cart: CartItem[];
+  addToCart: (item: CartItem) => void;
+  removeFromCart: (menuId: number) => void;
+  clearCart: () => void;
+};
+
+const CartContext = createContext<CartContextType | undefined>(undefined);
+
+export function CartProvider({ children }: { children: React.ReactNode }) {
+  const [cart, setCart] = useState<CartItem[]>([]);
+
+  // localStorage 초기화
+  useEffect(() => {
+    const stored = localStorage.getItem("cart");
+    if (stored) {
+      setCart(JSON.parse(stored));
+    }
+  }, []);
+
+  // cart 바뀔 때마다 localStorage에 저장
+  useEffect(() => {
+    localStorage.setItem("cart", JSON.stringify(cart));
+  }, [cart]);
+
+  const addToCart = (item: CartItem) => {
+    setCart((prev) => {
+      const exists = prev.find((i) => i.menu.id === item.menu.id);
+      if (exists) {
+        return prev.map((i) =>
+          i.menu.id === item.menu.id ? { ...i, quantity: i.quantity + item.quantity } : i
+        );
+      }
+      return [...prev, item];
+    });
+  };
+
+  const removeFromCart = (menuId: number) => {
+    setCart((prev) => prev.filter((item) => item.menu.id !== menuId));
+  };
+
+  const clearCart = () => {
+    setCart([]);
+  };
+
+  return (
+    <CartContext.Provider value={{ cart, addToCart, removeFromCart, clearCart }}>
+      {children}
+    </CartContext.Provider>
+  );
+}
+
+export function useCart() {
+  const context = useContext(CartContext);
+  if (!context) throw new Error("useCart는 <CartProvider> 내부에서만 사용해야 합니다.");
+  return context;
+}

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -2,6 +2,7 @@ import { Montserrat, Inter } from "next/font/google";
 import Header from "@/_components/Header";
 import { ToastContainer } from "react-toastify";
 import { AuthProvider } from "@/_hooks/auth-context";
+import { CartProvider } from "@/_contexts/CartContext";
 import "react-toastify/dist/ReactToastify.css";
 import "./globals.css";
 
@@ -28,20 +29,20 @@ export default function RootLayout({
     <html lang="ko">
       <body className={`${inter.variable} ${montserrat.variable} font-sans antialiased`}>
         <AuthProvider>
-          <Header />
+          <CartProvider> 
+            <Header />
 
-          {/* 전역 토스트 컨테이너 */}
-          <ToastContainer
-            position="top-center"
-            autoClose={2000}
-            hideProgressBar
-            pauseOnHover
-            closeOnClick
-            theme="light"
-          />
+            <ToastContainer
+              position="top-center"
+              autoClose={2000}
+              hideProgressBar
+              pauseOnHover
+              closeOnClick
+              theme="light"
+            />
 
-          {/* 페이지 콘텐츠 */}
-          {children}
+            {children}
+          </CartProvider>
         </AuthProvider>
       </body>
     </html>


### PR DESCRIPTION
### 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
context와 localStorage를 활용하여 새로고침하거나 다른 페이지로 이동해도 장바구니가 보존되도록 수정했습니다.

### 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
OrderPage → 전역 CartContext를 통해 장바구니 상태 관리
CartItemCard, MenuCard → 그대로 사용 가능 (props 통해 로직 전달)
localStorage 연동됨 → 새로고침해도 장바구니 보존

### ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
현재 로그인 상태 유지 부분에 보완할 부분이 있어서 그 부분 수정한 다음, 
메뉴 목록에 이미지 나타나도록 수정하면 큰 부분은 마무리될 것 같습니다.