### PR TITLE
feat: 관리자 페이지 접근 시 로그인 여부 확인 및 리다이렉트 기능 추가

### DIFF
--- a/frontend/src/_hooks/useLogin.ts
+++ b/frontend/src/_hooks/useLogin.ts
@@ -17,7 +17,7 @@ export function useLogin() {
   const [isLoading, setIsLoading] = useState(false);
   const { login: authLogin } = useAuth(); 
 
-  const login = async (form: LoginForm) => {
+  const login = async (form: LoginForm, redirectTo: string = "/order") => {
     setIsLoading(true);
 
     const validationError = validateLoginForm(form);
@@ -38,7 +38,7 @@ export function useLogin() {
 
       authLogin(); // 전역 로그인 상태 true
       toast.success("로그인 성공");
-      router.push("/order");
+      router.push(redirectTo);
     } catch (err: any) {
       toast.error(err.message || "로그인에 실패했습니다.");
     } finally {

--- a/frontend/src/app/admin/layout.tsx
+++ b/frontend/src/app/admin/layout.tsx
@@ -1,6 +1,26 @@
-import { ReactNode } from "react";
+"use client";
+
+import { ReactNode, useEffect } from "react";
+import { useRouter, usePathname } from "next/navigation";
+import { useAuth } from "@/_hooks/auth-context";
+import { toast } from "react-toastify";
 
 export default function AdminLayout({ children }: { children: ReactNode }) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const { isLoggedIn } = useAuth();
+
+  useEffect(() => {
+    if (!isLoggedIn) {
+      toast.error("로그인이 필요합니다.");
+      router.push(`/login?from=${pathname}`);
+    }
+  }, [isLoggedIn, router, pathname]);
+
+  if (!isLoggedIn) {
+    return null;
+  }
+
   return (
     <div className="flex min-h-screen">
       {/* 사이드바 */}

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -1,11 +1,14 @@
 "use client";
 
 import { useState } from "react";
+import { useSearchParams } from "next/navigation";
 import { useLogin } from "@/_hooks/useLogin";
 import { LoginForm } from "@/types";
 import { InputField } from "@/_components/ui/InputField";
 
 export default function LoginPage() {
+  const searchParams = useSearchParams();
+  const from = searchParams.get("from") || "/order";
   const { login, isLoading } = useLogin();
   const [form, setForm] = useState<LoginForm>({ email: "", password: "" });
 
@@ -15,7 +18,7 @@ export default function LoginPage() {
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    login(form);
+    login(form, from);
   };
 
   return (


### PR DESCRIPTION
## 📌 과제 설명
- 관리자 페이지 접근 시 인증되지 않은 사용자는 로그인 페이지로 리다이렉트 되도록 처리
- 로그인 후 원래 요청했던 경로로 다시 이동할 수 있도록 리다이렉트 로직을 구현

## 👩‍💻 요구 사항과 구현 내용
- `AdminLayout`에서 로그인 여부를 확인하고, 미로그인 시 `/login`으로 이동하도록 처리
- `useLogin` 훅 내부에 `redirectTo` 기능 추가 → 로그인 후 `from` 파라미터를 기반으로 원래 페이지로 이동
- 로그인 페이지 진입 시 쿼리 파라미터 `from`을 통해 리다이렉트 경로를 유지
- 로그인 완료 시 `router.push(from || "/admin")` 방식으로 최종 이동 경로 결정

## ✅ PR 포인트 & 궁금한 점
로그인하지 않은 사용자가 관리자 페이지 접근 시, 로그인 페이지로 이동하도록 개선하였습니다.