### PR TITLE
feat: accessToken 만료 시 자동 재발급 로직 구현 (Refresh Token 기반)

### DIFF
--- a/backend/src/main/java/com/back/domain/member/member/entity/Member.java
+++ b/backend/src/main/java/com/back/domain/member/member/entity/Member.java
@@ -17,12 +17,16 @@ public class Member extends BaseEntity{
     private String nickname;
     private String password;
     private String address;
+
     @Column(unique = true)
     private String apiKey;
 
     // 기존 Role 중복 삭제(태열님 코드로 교체)
     @Enumerated(EnumType.STRING)
     private Role role = Role.USER;
+
+    @Column(length = 1000)
+    private String refreshToken;
 
     // 관리자 생성 임시 메서드입니다.(추후 삭제 예정)
     public Member(String email, String password, String nickname, String address, Role role) {
@@ -45,4 +49,6 @@ public class Member extends BaseEntity{
     public void modifyApiKey(String apiKey) {
         this.apiKey = apiKey;
     }
+    public void updateRefreshToken(String refreshToken) { this.refreshToken = refreshToken; }
+    public void clearRefreshToken() { this.refreshToken = null; }
 }

--- a/backend/src/main/java/com/back/domain/member/member/service/AuthTokenService.java
+++ b/backend/src/main/java/com/back/domain/member/member/service/AuthTokenService.java
@@ -15,15 +15,32 @@ public class AuthTokenService {
     @Value("${custom.accessToken.expirationSeconds}")
     private int accessTokenExpirationSeconds;
 
+    @Value("${custom.refreshToken.expirationSeconds}")
+    private int refreshTokenExpirationSeconds;
+
     String genAccessToken(Member member) {
         int id = member.getId();
         String email = member.getEmail();
         String nickName = member.getNickname();
+        String role = member.getRole().name(); // 추가
 
         return Ut.jwt.toString(
                 jwtSecretKey,
                 accessTokenExpirationSeconds,
-                Map.of("id", id, "email", email, "nickName", nickName)
+                Map.of(
+                        "id", id,
+                        "email", email,
+                        "nickName", nickName,
+                        "role", role
+                )
+        );
+    }
+
+    public String genRefreshToken(Member member) {
+        return Ut.jwt.toString(
+                jwtSecretKey,
+                refreshTokenExpirationSeconds,
+                Map.of("id", member.getId(), "email", member.getEmail())
         );
     }
 
@@ -36,5 +53,9 @@ public class AuthTokenService {
         String email = (String) parsedPayload.get("email");
 
         return Map.of("id", id, "email", email);
+    }
+
+    public boolean isValid(String token) {
+        return Ut.jwt.isValid(jwtSecretKey, token);
     }
 }

--- a/backend/src/main/java/com/back/domain/member/member/service/MemberService.java
+++ b/backend/src/main/java/com/back/domain/member/member/service/MemberService.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 @Service
@@ -19,6 +20,10 @@ public class MemberService {
     private final MemberRepository memberRepository;
     private final PasswordEncoder passwordEncoder;
     private final AuthTokenService authTokenService;
+
+    public Member save(Member member) {
+        return memberRepository.save(member);
+    }
 
     public Member join(String email, String password, String nickname, String address) {
         Member member = new Member(email, password, nickname, address);
@@ -49,5 +54,23 @@ public class MemberService {
 
     public String genAccessToken(Member member) {
         return authTokenService.genAccessToken(member);
+    }
+
+    public String genRefreshToken(Member member) {
+        String refreshToken = authTokenService.genRefreshToken(member);
+        member.updateRefreshToken(refreshToken);
+        return refreshToken;
+    }
+
+    public void clearRefreshToken(Member member) {
+        member.clearRefreshToken();
+    }
+
+    public boolean isValidRefreshToken(String refreshToken) {
+        return authTokenService.isValid(refreshToken);
+    }
+
+    public Map<String, Object> getRefreshTokenPayload(String refreshToken) {
+        return authTokenService.payload(refreshToken);
     }
 }

--- a/backend/src/main/java/com/back/global/rq/Rq.java
+++ b/backend/src/main/java/com/back/global/rq/Rq.java
@@ -33,12 +33,21 @@ public class Rq {
         Cookie cookie = new Cookie(name, value);
         cookie.setPath("/");
         cookie.setHttpOnly(true);
-        cookie.setDomain("localhost");
         cookie.setSecure(true);
-        cookie.setAttribute("SameSite", "Strict");
+        cookie.setAttribute("SameSite", "None");
+        cookie.setDomain("localhost");
 
-        if (value.isBlank()) cookie.setMaxAge(0);
-        else cookie.setMaxAge(60 * 60 * 24 * 365);
+        if (value.isBlank()) {
+            cookie.setMaxAge(0); // 즉시 만료
+        } else {
+            if (name.equals("accessToken")) {
+                cookie.setMaxAge(60 * 20); // 20분
+            } else if (name.equals("refreshToken")) {
+                cookie.setMaxAge(60 * 60 * 24 * 7); // 7일
+            } else {
+                cookie.setMaxAge(60 * 60 * 24 * 365); // 1년
+            }
+        }
 
         resp.addCookie(cookie);
     }

--- a/backend/src/main/java/com/back/global/security/SecurityConfig.java
+++ b/backend/src/main/java/com/back/global/security/SecurityConfig.java
@@ -31,7 +31,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/h2-console/**").permitAll()
                         // 회원가입+로그인+로그아웃 API 인증 상태 확인 허용
-                        .requestMatchers("/signup", "/login", "/auth/me", "/logout").permitAll()
+                        .requestMatchers("/signup", "/login", "/auth/me", "/logout", "/reissue").permitAll()
                         .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
                         .requestMatchers("/admin/**").hasRole("ADMIN")
                         .anyRequest().authenticated()

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -33,3 +33,5 @@ custom:
     secretKey: abcdefghijklmnopqrstuvwxyz1234567890abcdefghijklmnopqrstuvwxyz1234567890
   accessToken:
     expirationSeconds: 1200
+  refreshToken:
+    expirationSeconds: 604800

--- a/frontend/src/_hooks/useOrder.ts
+++ b/frontend/src/_hooks/useOrder.ts
@@ -42,6 +42,7 @@ export function useOrder() {
       });
 
       toast.success("주문이 완료되었습니다.");
+      await new Promise((res) => setTimeout(res, 700));
       clearCart(); // 장바구니 비우기 
       router.push("/mypage");
     } catch (err: unknown) {


### PR DESCRIPTION
closes #92 
### 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
accessToken 만료 시, 자동으로 refreshToken을 이용해 accessToken을 재발급하고 재요청하는 로직을 구현했습니다. 프론트에서는 401 응답을 감지하여 `/reissue` 요청을 보내고, 재발급 성공 시 원래 요청을 다시 시도하도록 처리했습니다.

### 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
### 🌐 백엔드
- JwtAuthenticationFilter 개선
  - 유효하지 않은 accessToken → 명시적으로 401 반환
  - 익명 요청은 허용
- `/reissue` API 구현
  - refreshToken 쿠키 기반으로 accessToken 재발급
  - 서버 저장 토큰과 비교하여 일치 여부 확인
- Rq 유틸의 `setCookie()` 내부에 secure, httpOnly, SameSite 설정 반영
- SecurityConfig에서 `/reissue` 경로 인증 제외 처리

### 💻 프론트엔드
- `apiFetch.ts` 개선
  - 401 발생 시 자동으로 `/reissue` 요청
  - 성공 시 딜레이 후 원래 요청 재시도
  - 실패 시 "세션 만료" 에러 처리
- credentials: "include" 설정으로 쿠키 자동 포함 처리

### ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
인증 로직의 안정성과 확장성을 확보했습니다. 이제 accessToken 만료 시 로그아웃 없이 매끄럽게 유지됩니다. 