### PR TITLE
feat: 관리자 레이아웃에 로그인 로딩 처리 및 관리자 권한 확인 기능 추가

### DIFF
--- a/frontend/src/_hooks/auth-context.tsx
+++ b/frontend/src/_hooks/auth-context.tsx
@@ -2,13 +2,10 @@
 
 import { createContext, useContext, useEffect, useState } from "react";
 import { apiFetch } from "@/lib/apiFetch";
-import { User } from "@/types/auth";
 
 type AuthContextType = {
   isLoggedIn: boolean;
   isLoading: boolean;
-  user: User | null;
-  isAdmin: boolean;
   login: () => void;
   logout: () => void;
 };
@@ -23,11 +20,9 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   useEffect(() => {
     (async () => {
       try {
-        const userData = await apiFetch("/auth/me"); // 로그인된 유저 정보 확인
-        setUser(userData);
+        await apiFetch("/auth/me"); // 로그인된 유저 정보 확인
         setIsLoggedIn(true);
       } catch {
-        setUser(null);
         setIsLoggedIn(false);
       } finally {
         setIsLoading(false);
@@ -40,14 +35,13 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const logout = async () => {
     try {
       await apiFetch("/logout", { method: "POST" });
-      setUser(null);
       setIsLoggedIn(false);
     } catch (err: any) {
     }
   };
 
   return (
-    <AuthContext.Provider value={{ isLoggedIn, isLoading, user, isAdmin, login, logout }}>
+    <AuthContext.Provider value={{ isLoggedIn, isLoading, login, logout }}>
       {children}
     </AuthContext.Provider>
   );

--- a/frontend/src/app/admin/layout.tsx
+++ b/frontend/src/app/admin/layout.tsx
@@ -1,15 +1,17 @@
 "use client";
 
-import { ReactNode, useEffect } from "react";
+import { ReactNode, useEffect, useState } from "react";
 import { useRouter, usePathname } from "next/navigation";
 import { useAuth } from "@/_hooks/auth-context";
 import { toast } from "react-toastify";
+import { apiFetch } from "@/lib/apiFetch";
 
 export default function AdminLayout({ children }: { children: ReactNode }) {
   const router = useRouter();
   const pathname = usePathname();
-  const { isLoggedIn } = useAuth();
   const { isLoggedIn, isLoading } = useAuth();
+  const [isChecking, setIsChecking] = useState(true);
+  const [hasAdminAccess, setHasAdminAccess] = useState(false);
 
   useEffect(() => {
     if (isLoading) return;
@@ -17,12 +19,37 @@ export default function AdminLayout({ children }: { children: ReactNode }) {
     if (!isLoggedIn) {
       toast.error("로그인이 필요합니다.");
       router.push(`/login?from=${pathname}`);
-    }
-  }, [isLoggedIn, router, pathname]);
       return;
     }
 
-  if (!isLoggedIn) {
+    // 관리자 권한을 API 호출로 확인
+    const checkAdminAccess = async () => {
+      try {
+        // 간단한 admin API 호출로 권한 확인 (예: admin/orders)
+        await apiFetch("/admin/orders");
+        setHasAdminAccess(true);
+      } catch (error: any) {
+        if (error.message?.includes("403") || error.message?.includes("권한")) {
+          toast.error("관리자 권한이 없습니다.");
+          router.push("/");
+        } else if (error.message?.includes("401") || error.message?.includes("로그인")) {
+          toast.error("로그인이 필요합니다.");
+          router.push(`/login?from=${pathname}`);
+        } else {
+          // 기타 에러는 권한 없음으로 처리
+          toast.error("관리자 권한이 없습니다.");
+          router.push("/");
+        }
+        setHasAdminAccess(false);
+      } finally {
+        setIsChecking(false);
+      }
+    };
+
+    checkAdminAccess();
+  }, [isLoggedIn, isLoading, router, pathname]);
+
+  if (isLoading || isChecking || !isLoggedIn || !hasAdminAccess) {
     return null;
   }
 

--- a/frontend/src/app/admin/layout.tsx
+++ b/frontend/src/app/admin/layout.tsx
@@ -9,13 +9,18 @@ export default function AdminLayout({ children }: { children: ReactNode }) {
   const router = useRouter();
   const pathname = usePathname();
   const { isLoggedIn } = useAuth();
+  const { isLoggedIn, isLoading } = useAuth();
 
   useEffect(() => {
+    if (isLoading) return;
+    
     if (!isLoggedIn) {
       toast.error("로그인이 필요합니다.");
       router.push(`/login?from=${pathname}`);
     }
   }, [isLoggedIn, router, pathname]);
+      return;
+    }
 
   if (!isLoggedIn) {
     return null;

--- a/frontend/src/app/mypage/page.tsx
+++ b/frontend/src/app/mypage/page.tsx
@@ -47,7 +47,7 @@ function getCompactPagination(current: number, total: number): (number | "...")[
 export default function MyPage() {
   const router = useRouter();
   const searchParams = useSearchParams();
-  const { isLoggedIn } = useAuth();
+  const { isLoggedIn, isLoading } = useAuth();
 
   const initialPage = Number(searchParams.get("page")) || 0;
 
@@ -60,7 +60,10 @@ export default function MyPage() {
     router.replace(`/mypage?page=${page}`);
   }, [page, router]);
 
+  // 로그인 여부 확인 및 주문 목록 로드
   useEffect(() => {
+    if (isLoading) return; // 로딩 중이면 아무것도 하지 않음
+
     if (!isLoggedIn) {
       toast.error("로그인이 필요합니다.");
       router.push("/login");
@@ -75,7 +78,10 @@ export default function MyPage() {
       .catch((err) => {
         toast.error("주문 내역 불러오기 실패: " + err.message);
       });
-  }, [isLoggedIn, page, router]);
+  }, [isLoading, isLoggedIn, page, router]);
+
+  // 로딩 중일 때는 아무 것도 렌더링하지 않음
+  if (isLoading) return null;
 
   return (
     <div className="p-6 max-w-4xl mx-auto">


### PR DESCRIPTION
## 📌 과제 설명
- 관리자 페이지 접근 시 로그인 상태 로딩을 처리
- 관리자 권한이 있는지 여부를 확인하는 로직을 추가
- 인증 및 권한 확인 처리를 통해 비정상 접근을 방지

## 👩‍💻 요구 사항과 구현 내용
- `AdminLayout` 컴포넌트에서 로그인 상태 확인 중일 때 로딩 화면을 보여주도록 처리
- `AuthContext`의 로직을 정리하고, `user` 및 `isAdmin` 상태 관리를 별도 컴포넌트에서 담당하도록 리팩토링
- 로그인된 사용자의 권한을 확인하여 관리자가 아닌 경우 접근 제한 (안내 메시지 처리)

## ✅ PR 포인트 & 궁금한 점
- 로그인이 아직 확인되지 않았을 때의 상태(로딩 중)와, 로그인은 되었지만 관리자가 아닌 경우를 구분해서 처리하는 데 중점을 두었습니다. 관리자가 아닌 사용자가 관리자 페이지에 접근하지 못하게 막았습니다.
- AuthContext는 이제 더 단순한 역할만 맡고 있고, 실제 유저 정보나 관리자 권한은 다른 곳에서 따로 관리하도록 바꿨습니다. 유저 정보와 관리자 권한은 src/app/admin/layout.tsx의 AdminLayout 컴포넌트 내부에서 API를 통해 직접 확인합니다.