### PR TITLE
feat: 관리자 로그인 분기 + UI 접근 제어 개선

### DIFF
--- a/backend/src/main/java/com/back/domain/member/member/dto/MemberDto.java
+++ b/backend/src/main/java/com/back/domain/member/member/dto/MemberDto.java
@@ -1,18 +1,21 @@
 package com.back.domain.member.member.dto;
 
 import com.back.domain.member.member.entity.Member;
+import com.back.domain.member.member.entity.Role;
 
 public record MemberDto(
         String email,
         String password,
         String nickname,
-        String address
+        String address,
+        Role role
 ) {
-    public MemberDto(String email, String password, String nickname, String address) {
+    public MemberDto(String email, String password, String nickname, String address, Role role) {
         this.email = email;
         this.password = password;
         this.nickname = nickname;
         this.address = address;
+        this.role = role;
     }
 
     public MemberDto(Member member) {
@@ -20,7 +23,8 @@ public record MemberDto(
                 member.getEmail(),
                 member.getPassword(),
                 member.getNickname(),
-                member.getAddress()
+                member.getAddress(),
+                member.getRole()
         );
     }
 }

--- a/backend/src/main/java/com/back/global/security/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/back/global/security/JwtAuthenticationFilter.java
@@ -50,12 +50,13 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             // 토큰이 유효한 경우 → 인증 처리
             Map<String, Object> payload = jwt.payload(secret, token);
             String email = (String) payload.get("email");
+            String role = (String) payload.get("role");
 
             Member member = memberRepository.findByEmail(email)
                     .orElseThrow(() -> new RuntimeException("사용자 정보를 찾을 수 없습니다."));
 
             List<SimpleGrantedAuthority> authorities =
-                    Collections.singletonList(new SimpleGrantedAuthority("ROLE_" + member.getRole().name()));
+                    Collections.singletonList(new SimpleGrantedAuthority("ROLE_" + role));
 
             SecurityUser securityUser = new SecurityUser(member, authorities);
 

--- a/frontend/src/_components/Header.tsx
+++ b/frontend/src/_components/Header.tsx
@@ -8,7 +8,7 @@ export default function Header() {
   const router = useRouter();
   const pathname = usePathname();
 
-  const { isLoggedIn, logout } = useAuth();
+  const { isLoggedIn, user, logout } = useAuth();
 
   // 회원가입, 로그인 페이지에서는 헤더 숨김
   if (pathname === "/login" || pathname === "/signup") return null;
@@ -23,7 +23,8 @@ export default function Header() {
       <h1 className="text-3xl font-title font-bold">Grids & Circles</h1>
 
       <nav className="flex items-center gap-6 text-base">
-        {isLoggedIn && (
+        {/* 관리자 아닌 경우에만 표시 */}
+        {isLoggedIn && user?.role !== "ADMIN" && (
           <>
             <Link href="/order" className="hover:underline">
               주문하기

--- a/frontend/src/_hooks/auth-context.tsx
+++ b/frontend/src/_hooks/auth-context.tsx
@@ -13,6 +13,7 @@ type User = {
 type AuthContextType = {
   isLoggedIn: boolean;
   user: User | null;
+  isLoading: boolean;
   login: () => void;
   logout: () => void;
 };
@@ -22,6 +23,7 @@ const AuthContext = createContext<AuthContextType | undefined>(undefined);
 export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [isLoggedIn, setIsLoggedIn] = useState(false);
   const [user, setUser] = useState<User | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
 
   // 초기 mount 시 로그인 상태 및 사용자 정보 확인
   useEffect(() => {
@@ -33,18 +35,22 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       } catch {
         setUser(null);
         setIsLoggedIn(false);
+      } finally {
+        setIsLoading(false); 
       }
     })();
   }, []);
 
   const login = () => {
     setIsLoggedIn(true);
+    setIsLoading(true);
     apiFetch<User>("/auth/me")
       .then(setUser)
       .catch(() => {
         setIsLoggedIn(false);
         setUser(null);
-      });
+      })
+      .finally(() => setIsLoading(false)); 
   };
 
   const logout = async () => {
@@ -53,10 +59,11 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     } catch {}
     setIsLoggedIn(false);
     setUser(null);
+    setIsLoading(false); 
   };
 
   return (
-    <AuthContext.Provider value={{ isLoggedIn, user, login, logout }}>
+    <AuthContext.Provider value={{ isLoggedIn, user, isLoading, login, logout }}>
       {children}
     </AuthContext.Provider>
   );

--- a/frontend/src/_hooks/auth-context.tsx
+++ b/frontend/src/_hooks/auth-context.tsx
@@ -3,9 +3,16 @@
 import { createContext, useContext, useEffect, useState } from "react";
 import { apiFetch } from "@/lib/apiFetch";
 
+type User = {
+  email: string;
+  nickname: string;
+  address: string;
+  role: "ADMIN" | "USER";
+};
+
 type AuthContextType = {
   isLoggedIn: boolean;
-  isLoading: boolean;
+  user: User | null;
   login: () => void;
   logout: () => void;
 };
@@ -14,34 +21,42 @@ const AuthContext = createContext<AuthContextType | undefined>(undefined);
 
 export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [isLoggedIn, setIsLoggedIn] = useState(false);
-  const [isLoading, setIsLoading] = useState(true);
+  const [user, setUser] = useState<User | null>(null);
 
-  // 초기 mount 시 서버로 로그인 상태 확인
+  // 초기 mount 시 로그인 상태 및 사용자 정보 확인
   useEffect(() => {
     (async () => {
       try {
-        await apiFetch("/auth/me"); // 로그인된 유저 정보 확인
+        const userData = await apiFetch<User>("/auth/me");
+        setUser(userData);
         setIsLoggedIn(true);
       } catch {
+        setUser(null);
         setIsLoggedIn(false);
-      } finally {
-        setIsLoading(false);
       }
     })();
   }, []);
 
-  const login = () => setIsLoggedIn(true);
+  const login = () => {
+    setIsLoggedIn(true);
+    apiFetch<User>("/auth/me")
+      .then(setUser)
+      .catch(() => {
+        setIsLoggedIn(false);
+        setUser(null);
+      });
+  };
 
   const logout = async () => {
     try {
       await apiFetch("/logout", { method: "POST" });
-      setIsLoggedIn(false);
-    } catch (err: any) {
-    }
+    } catch {}
+    setIsLoggedIn(false);
+    setUser(null);
   };
 
   return (
-    <AuthContext.Provider value={{ isLoggedIn, isLoading, login, logout }}>
+    <AuthContext.Provider value={{ isLoggedIn, user, login, logout }}>
       {children}
     </AuthContext.Provider>
   );

--- a/frontend/src/_hooks/useLogin.ts
+++ b/frontend/src/_hooks/useLogin.ts
@@ -15,9 +15,9 @@ const validateLoginForm = (form: LoginForm): string | null => {
 export function useLogin() {
   const router = useRouter();
   const [isLoading, setIsLoading] = useState(false);
-  const { login: authLogin } = useAuth(); 
+  const { login: authLogin } = useAuth();
 
-  const login = async (form: LoginForm, redirectTo: string = "/order") => {
+  const login = async (form: LoginForm) => {
     setIsLoading(true);
 
     const validationError = validateLoginForm(form);
@@ -28,6 +28,7 @@ export function useLogin() {
     }
 
     try {
+      // 로그인 요청
       await apiFetch("/login", {
         method: "POST",
         headers: {
@@ -36,9 +37,18 @@ export function useLogin() {
         body: JSON.stringify(form),
       });
 
-      authLogin(); // 전역 로그인 상태 true
+      // 로그인 후 사용자 정보 조회
+      const user = await apiFetch<{ role: string }>("/auth/me");
+
+      // 전역 상태 설정 및 분기
+      authLogin();
       toast.success("로그인 성공");
-      router.push(redirectTo);
+
+      if (user.role === "ADMIN") {
+        router.push("/admin/orders");
+      } else {
+        router.push("/order");
+      }
     } catch (err: any) {
       toast.error(err.message || "로그인에 실패했습니다.");
     } finally {

--- a/frontend/src/app/admin/layout.tsx
+++ b/frontend/src/app/admin/layout.tsx
@@ -4,54 +4,32 @@ import { ReactNode, useEffect, useState } from "react";
 import { useRouter, usePathname } from "next/navigation";
 import { useAuth } from "@/_hooks/auth-context";
 import { toast } from "react-toastify";
-import { apiFetch } from "@/lib/apiFetch";
 
 export default function AdminLayout({ children }: { children: ReactNode }) {
   const router = useRouter();
   const pathname = usePathname();
-  const { isLoggedIn, isLoading } = useAuth();
+  const { isLoggedIn, isLoading, user } = useAuth(); 
   const [isChecking, setIsChecking] = useState(true);
-  const [hasAdminAccess, setHasAdminAccess] = useState(false);
 
   useEffect(() => {
     if (isLoading) return;
-    
-    if (!isLoggedIn) {
+
+    if (!isLoggedIn || !user) {
       toast.error("로그인이 필요합니다.");
       router.push(`/login?from=${pathname}`);
       return;
     }
 
-    // 관리자 권한을 API 호출로 확인
-    const checkAdminAccess = async () => {
-      try {
-        // 간단한 admin API 호출로 권한 확인 (예: admin/orders)
-        await apiFetch("/admin/orders");
-        setHasAdminAccess(true);
-      } catch (error: any) {
-        if (error.message?.includes("403") || error.message?.includes("권한")) {
-          toast.error("관리자 권한이 없습니다.");
-          router.push("/");
-        } else if (error.message?.includes("401") || error.message?.includes("로그인")) {
-          toast.error("로그인이 필요합니다.");
-          router.push(`/login?from=${pathname}`);
-        } else {
-          // 기타 에러는 권한 없음으로 처리
-          toast.error("관리자 권한이 없습니다.");
-          router.push("/");
-        }
-        setHasAdminAccess(false);
-      } finally {
-        setIsChecking(false);
-      }
-    };
+    if (user.role !== "ADMIN") {
+      toast.error("관리자 권한이 없습니다.");
+      router.push("/");
+      return;
+    }
 
-    checkAdminAccess();
-  }, [isLoggedIn, isLoading, router, pathname]);
+    setIsChecking(false);
+  }, [isLoggedIn, isLoading, user, pathname, router]);
 
-  if (isLoading || isChecking || !isLoggedIn || !hasAdminAccess) {
-    return null;
-  }
+  if (isLoading || isChecking) return null;
 
   return (
     <div className="flex min-h-screen">

--- a/frontend/src/lib/apiFetch.ts
+++ b/frontend/src/lib/apiFetch.ts
@@ -20,10 +20,10 @@ export async function apiFetch<T>(
     });
 
     if (reissueRes.ok) {
-      // ✅ 쿠키 반영까지 아주 잠깐 delay → 브라우저에 반영될 시간 확보
+      // 쿠키 반영까지 아주 잠깐 delay → 브라우저에 반영될 시간 확보
       await new Promise((r) => setTimeout(r, 100)); // 100ms 딜레이
 
-      // ✅ 원래 요청 재시도
+      // 원래 요청 재시도
       res = await fetch(`${baseUrl}${url}`, {
         ...options,
         headers: {


### PR DESCRIPTION
Closes #76 

### 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
말씀 주셨던 관리자 로그인 시 페이지 접속이 안되는 부분 수정했습니다. 

### 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
- 로그인 시 사용자 role에 따라 페이지 분기 (ADMIN → /admin/orders, USER → /order)
- 관리자 로그인 시 Header에서 사용자용 메뉴 숨김 처리
- AdminLayout에서 관리자 권한을 검증 후 접근 허용
- auth-context에 isLoading 상태 추가 및 로직 정비
- 관리자 권한 없을 경우 알림 토스트 후 홈(/)으로 리다이렉트 처리
- 일반 사용자 또는 비로그인 사용자가 /admin/* 경로 접근 시 강제 리다이렉트 및 메시지 출력
- 관리자 페이지 내 다른 경로 이동 시에도 로그아웃 문제 해결

### ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
우선 저는 다 테스트해보기는 했는데, 그래도 확인해보시고 문제 발생하면 말해주세요 !!